### PR TITLE
Hard fork 1 again

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -24,6 +24,8 @@ var config = {
             bwGrowth: 10000000,
             // the maximum bandwidth an account can have available
             bwMax: 256000,
+            // controls if unpaid votes should be capped to the amount needed to generate 1 token
+            capUnpaidVotes: false,
             // the number of rounds of consensus before block is valid (min 2)
             consensusRounds: 2,
             // the number of blocks from the past taken into consideration for econonomics
@@ -93,6 +95,16 @@ var config = {
             vtGrowth: 360000000, // +1 vt per hour per DTC
             vtPerBurn: 6 // can be updated in the future to modify incentives
         },
+        1000020: {
+            capUnpaidVotes: true,
+            ecoBlocks: 2400,
+            leaders: 7,
+            leaderRewardVT: 10,
+            rewardPoolMult: 300
+        },
+        1002420: {
+            rewardPoolMult: 200
+        }
         // example hardforks
         // 2100: {
         //     leaders: 10,
@@ -109,8 +121,11 @@ var config = {
     read: (blockNum) => {
         var finalConfig = {}
         for (const key in config.history) 
-            if (blockNum >= key)
+            if (blockNum >= key) {
+                if (blockNum === parseInt(key) && blockNum !== 0)
+                    logr.info('Hard Fork #'+key)
                 Object.assign(finalConfig, config.history[key])
+            }
             else break
         
         return finalConfig

--- a/src/config.js
+++ b/src/config.js
@@ -95,14 +95,14 @@ var config = {
             vtGrowth: 360000000, // +1 vt per hour per DTC
             vtPerBurn: 6 // can be updated in the future to modify incentives
         },
-        1000020: {
+        1200010: {
             capUnpaidVotes: true,
             ecoBlocks: 2400,
             leaders: 10,
             leaderRewardVT: 10,
             rewardPoolMult: 300
         },
-        1002420: {
+        1002410: {
             rewardPoolMult: 200
         }
         // example hardforks

--- a/src/config.js
+++ b/src/config.js
@@ -98,7 +98,7 @@ var config = {
         1000020: {
             capUnpaidVotes: true,
             ecoBlocks: 2400,
-            leaders: 7,
+            leaders: 10,
             leaderRewardVT: 10,
             rewardPoolMult: 300
         },

--- a/src/economics.js
+++ b/src/economics.js
@@ -193,6 +193,11 @@ var eco = {
                 if (err) throw err
                 if (!account.uv) account.uv = 0
 
+                if (stats.avail === 0) {
+                    cb(0)
+                    return
+                }
+
                 //logr.trace('DIST:', name, vt, ts, account.uv, stats)
 
                 var thNewCoins = 0
@@ -216,6 +221,11 @@ var eco = {
                 unpaidVotes *= stats.votes
                 if (vt<0) unpaidVotes = Math.ceil(unpaidVotes)
                 else unpaidVotes = Math.floor(unpaidVotes)
+
+                // unpaid votes is meant for minnows who struggle to print 1 unit
+                // not the big whales where votes exceed the rewardPoolMaxShare
+                if (config.capUnpaidVotes && unpaidVotes > Math.floor(stats.votes/stats.avail))
+                    unpaidVotes = Math.floor(stats.votes/stats.avail)
 
                 //console.log(newCoins, unpaidVotes)
                 var changes = {

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 // starting sub modules
-config = require('./config.js').read(0)
 logr = require('./logger.js')
+config = require('./config.js').read(0)
 http = require('./http.js')
 p2p = require('./p2p.js')
 mongo = require('./mongo.js')

--- a/src/mongo.js
+++ b/src/mongo.js
@@ -56,7 +56,8 @@ var mongo = {
     fillInMemoryBlocks: (cb) => {
         db.collection('blocks').find({}, {
             sort: {_id: -1},
-            limit: config.ecoBlocks
+            limit: config.ecoBlocks*2
+            // TODO: remove the *2 after HF1
         }).toArray(function(err, blocks) {
             if (err) throw err
             chain.recentBlocks = blocks.reverse()


### PR DESCRIPTION
I ported changed we agreed upon before, then I added:

* Fix for Unpaid Votes (see current `rt-international` account). Happens when mega votes happen. Changes in economics.js will fix this issue.

* Fix for the issue in mongo.js around increasing `ecoBlocks` and making sure the node has enough blocks in memory at the moment of the hard-fork (i.e. if a node restarted less than 2400-1200 = 1200 blocks before the hard fork, some blocks would be missing from memory for the economy after the hardfork).

* Fix the issue where increasing `ecoBlocks` too fast would make the economy have 0 available tokens to print for the first X hours after the hard fork. So I suggest only increasing to 2400 blocks (2 hours) for now, and to do it in two steps by temporarily increasing the `rewardPoolMult` by 50% for the next 2400 blocks after the hardfork.

Bonus: will now display hard forks in the terminal output for the node >:)