### PR TITLE
Memory fix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,12 +13,15 @@ module.exports = {
         'config': 'writable',
         'http': 'writable',
         'p2p': 'writable',
+        'eco': 'writable',
+        'validate': 'writable',
         'mongo': 'writable',
         'chain': 'writable',
         'transaction': 'writable',
         'cache': 'writable',
         'notifications': 'writable',
         'closing': 'writable',
+        'rankings': 'writable',
         'newRankings': 'writable'
     },
     'parserOptions': {

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ npm-debug.log
 keys
 logs/*
 tmptx.json
+bin
+dump

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "scripts": {
     "start": "node src/main.js",
     "cli": "node src/cli.js",
-    "lint": "eslint 'src/*.js'"
+    "lint": "eslint 'src/*.js'",
+    "compile_cli": "pkg src/cli.js --out-path bin --targets node10-linux-x64,node10-linux-x86,node10-macos-x64,node10-macos-x86",
+    "compile_daemon": "pkg src/main.js --options stack-size=65500 --out-path bin --targets node10-linux-x64,node10-linux-x86,node10-macos-x64,node10-macos-x86"
+    
   },
   "dependencies": {
     "base-x": "^3.0.5",

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -10,7 +10,7 @@
 
 # Peering configuration
 #export OFFLINE=1
-#export NO_DISCOVERY=1
+export NO_DISCOVERY=1
 
 # trace / debug / info / warn /
 export LOG_LEVEL=info
@@ -19,8 +19,8 @@ export LOG_LEVEL=info
 #export PEERS=ws://51.255.82.70:6001
 export PEERS=ws://35.203.37.221:6001
 # your user and keys (only useful for active node owners)
-export NODE_OWNER=observer-node
-export NODE_OWNER_PUB=dTuBhkU6SUx9JEx1f4YEt34X9sC7QGso2dSrqE8eJyfz
-export NODE_OWNER_PRIV=34EpMEDFJwKbxaF7FhhLyEe3AhpM4dwHMLVfs4JyRto5
+export NODE_OWNER=tokyo
+export NODE_OWNER_PUB=23xNEcWn4g5BFKpPT3HNHb1poa2UdssjsAdNKq9Fz28Yu
+export NODE_OWNER_PRIV=5L8EYbaK2t2WtpcJcXL3zMZudh2D3awFJRxztnorv6Ai
 
 node --stack-size=65500 src/main

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -10,17 +10,20 @@
 
 # Peering configuration
 #export OFFLINE=1
-export NO_DISCOVERY=1
+#export NO_DISCOVERY=1
 
 # trace / debug / info / warn /
 export LOG_LEVEL=info
 
+# groups blocks during replay output to lower screen spam
+export REPLAY_OUTPUT=100
+
 # default peers to connect with on startup
-#export PEERS=ws://51.255.82.70:6001
 export PEERS=ws://35.203.37.221:6001
+
 # your user and keys (only useful for active node owners)
-export NODE_OWNER=tokyo
-export NODE_OWNER_PUB=23xNEcWn4g5BFKpPT3HNHb1poa2UdssjsAdNKq9Fz28Yu
-export NODE_OWNER_PRIV=5L8EYbaK2t2WtpcJcXL3zMZudh2D3awFJRxztnorv6Ai
+export NODE_OWNER=observer-node
+export NODE_OWNER_PUB=dTuBhkU6SUx9JEx1f4YEt34X9sC7QGso2dSrqE8eJyfz
+export NODE_OWNER_PRIV=34EpMEDFJwKbxaF7FhhLyEe3AhpM4dwHMLVfs4JyRto5
 
 node --stack-size=65500 src/main

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -12,8 +12,11 @@
 #export OFFLINE=1
 #export NO_DISCOVERY=1
 
-# trace / debug / info / warn /
-export LOG_LEVEL=info
+# Disabling notifications
+#export NOTIFICATIONS=1
+
+# trace / debug / info / warn
+export LOG_LEVEL=debug
 
 # groups blocks during replay output to lower screen spam
 export REPLAY_OUTPUT=100

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,6 +1,5 @@
 const series = require('run-series')
 const cloneDeep = require('clone-deep')
-
 var cache = {
     copy: {
         accounts: {},
@@ -14,27 +13,17 @@ var cache = {
     distributed: {},
     changes: [],
     inserts: [],
-    backup: function() {
-        cache.copy = {
-            accounts: {},
-            contents: {},
-            distributed: {},
-            changes: [],
-            inserts: []
-        }
-        cache.copy.accounts = cloneDeep(cache.accounts)
-        cache.copy.contents = cloneDeep(cache.contents)
-        cache.copy.distributed = cloneDeep(cache.distributed)
-        cache.copy.changes = cloneDeep(cache.changes)
-        cache.copy.inserts = cloneDeep(cache.inserts)
-        //logr.trace('Cache backup\'d')
-    },
     rollback: function() {
-        cache.accounts = cloneDeep(cache.copy.accounts)
-        cache.contents = cloneDeep(cache.copy.contents)
-        cache.distributed = cloneDeep(cache.copy.distributed)
-        cache.changes = cloneDeep(cache.copy.changes)
-        cache.inserts = cloneDeep(cache.copy.inserts)
+        for (const key in cache.copy.accounts)
+            cache.accounts[key] = cloneDeep(cache.copy.accounts[key])
+        for (const key in cache.copy.contents)
+            cache.contents[key] = cloneDeep(cache.copy.contents[key])
+        for (const key in cache.copy.distributed)
+            cache.distributed[key] = cloneDeep(cache.copy.distributed[key])
+        for (const key in cache.copy.changes)
+            cache.changes[key] = cloneDeep(cache.copy.changes[key])
+        for (const key in cache.copy.inserts)
+            cache.inserts[key] = cloneDeep(cache.copy.inserts[key])
         cache.copy.accounts = {}
         cache.copy.contents = {}
         cache.copy.distributed = {}
@@ -80,6 +69,10 @@ var cache = {
                 cb(null, false); return
             }
             var key = cache.keyByCollection(collection)
+
+            if (!cache.copy[collection][obj[key]])
+                cache.copy[collection][obj[key]] = cloneDeep(cache[collection][obj[key]])
+            
             for (var c in changes) 
                 switch (c) {
                 case '$inc':
@@ -228,6 +221,11 @@ var cache = {
             cb(err, results)
             cache.changes = []
             cache.inserts = []
+            cache.copy.accounts = {}
+            cache.copy.contents = {}
+            cache.copy.distributed = {}
+            cache.copy.changes = []
+            cache.copy.inserts = []
         })
     },
     keyByCollection: function(collection) {

--- a/src/chain.js
+++ b/src/chain.js
@@ -209,7 +209,7 @@ chain = {
             if (err) throw err
             // push cached accounts and contents to mongodb
             cache.writeToDisk(function() {
-                chain.cleanMemoryTx()
+                chain.cleanMemory()
 
                 // update the config if an update was scheduled
                 config = require('./config.js').read(block._id)
@@ -560,6 +560,22 @@ chain = {
     },    
     getFirstMemoryBlock: () => {
         return chain.recentBlocks[0]
+    },
+    cleanMemory: () => {
+        chain.cleanMemoryBlocks()
+        chain.cleanMemoryTx()
+    },
+    cleanMemoryBlocks: () => {
+        if (config.ecoBlocksIncreasesSoon) {
+            logr.trace('Keeping old blocks in memory because ecoBlocks is changing soon')
+            return
+        }
+            
+        var extraBlocks = chain.recentBlocks.length - config.ecoBlocks
+        while (extraBlocks > 0) {
+            chain.recentBlocks.splice(0,1)
+            extraBlocks--
+        }
     },
     cleanMemoryTx: () => {
         for (const hash in chain.recentTxs) 

--- a/src/config.js
+++ b/src/config.js
@@ -105,18 +105,6 @@ var config = {
         1202410: {
             rewardPoolMult: 200
         }
-        // example hardforks
-        // 2100: {
-        //     leaders: 10,
-        //     leaderRewardVT: 1,
-        //     txLimits: {
-        //         14: 2,
-        //         15: 2
-        //     }
-        // },
-        // 22500: {
-        //     rewardPoolMult: 200
-        // }
     },
     read: (blockNum) => {
         var finalConfig = {}
@@ -126,7 +114,14 @@ var config = {
                     logr.info('Hard Fork #'+key)
                 Object.assign(finalConfig, config.history[key])
             }
-            else break
+            else {
+                if (config.history[key].ecoBlocks > finalConfig.ecoBlocks
+                && config.history[key].ecoBlocks - finalConfig.ecoBlocks >= key-blockNum)
+                    finalConfig.ecoBlocksIncreasesSoon = config.history[key].ecoBlocks
+                
+                break
+            }
+            
         
         return finalConfig
     }

--- a/src/http.js
+++ b/src/http.js
@@ -122,6 +122,7 @@ var http = {
 
         // get in-memory data (intensive)
         app.get('/cache', (req,res) => {
+            //res.send(Object.keys(cache.accounts).length+' '+Object.keys(cache.contents).length)
             res.send(cache)
         })
         app.get('/cacheb', (req,res) => {

--- a/src/mongo.js
+++ b/src/mongo.js
@@ -56,12 +56,19 @@ var mongo = {
     fillInMemoryBlocks: (cb) => {
         db.collection('blocks').find({}, {
             sort: {_id: -1},
-            limit: config.ecoBlocks*2
-            // TODO: remove the *2 after HF1
+            limit: config.ecoBlocksIncreasesSoon ? config.ecoBlocksIncreasesSoon : config.ecoBlocks
         }).toArray(function(err, blocks) {
             if (err) throw err
             chain.recentBlocks = blocks.reverse()
             cb()
+        })
+    },
+    lastBlock: (cb) => {
+        db.collection('blocks').findOne({}, {
+            sort: {_id: -1}
+        }, function(err, block) {
+            if (err) throw err
+            cb(block)
         })
     }
 } 

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -1,9 +1,9 @@
 var TransactionType = require('./transactions').Types
-var disabled = process.env.NO_NOTIFICATION || true
+var isEnabled = process.env.NOTIFICATIONS || false
 
 notifications = {
     processBlock: (block) => {
-        if (disabled) return
+        if (!isEnabled) return
 
         if (block._id % config.notifPurge)
             notifications.purgeOld(block)

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -1,7 +1,10 @@
 var TransactionType = require('./transactions').Types
+var disabled = process.env.NO_NOTIFICATION || true
 
 notifications = {
     processBlock: (block) => {
+        if (disabled) return
+
         if (block._id % config.notifPurge)
             notifications.purgeOld(block)
 


### PR DESCRIPTION
- Improved caching for blocks, accounts and contents.

- Notifications processing is now off by default. Add `NOTIFICATIONS=1` to re-enable them like before. This change also improves replay speed by a lot.

- Blocks are grouped for the screen output during replay now. It only display 1 block out of 100 by default and it's customizable with `REPLAY_OUTPUT=XXX`

This improves the replay speed by a lot. My PC goes to 200-300 blocks/sec 