### PR TITLE
fix vp & dtc block rewards

### DIFF
--- a/src/chain.js
+++ b/src/chain.js
@@ -546,7 +546,7 @@ chain = {
             
             newVt.v += config.leaderRewardVT
 
-            if (config.leaderReward > 0 && config.leaderRewardVT > 0)
+            if (config.leaderReward > 0 || config.leaderRewardVT > 0)
                 cache.updateOne('accounts', 
                     {name: account.name},
                     {$set: {
@@ -555,10 +555,8 @@ chain = {
                     }},
                     function(err) {
                         if (err) throw err
-                        transaction.updateGrowInts(account, ts, function() {
-                            transaction.adjustNodeAppr(account, config.leaderReward, function() {
-                                cb(config.leaderReward)
-                            })
+                        transaction.adjustNodeAppr(account, config.leaderReward, function() {
+                            cb(config.leaderReward)
                         })
                     })
             else cb(0)


### PR DESCRIPTION
GrowInt was unnecessarily updated twice for VP rewards, resulting in VP reward not adding correctly as the second GrowInt update reassigned the original VP value without the block reward.

A hardfork may be required which is not included in this pull request.