### PR TITLE
Improved docker configs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+npm-debug.log
+Dockerfile*
+docker-compose*
+.dockerignore
+.git
+.gitignore
+README.md
+LICENSE
+.vscode

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ docker-compose*
 README.md
 LICENSE
 .vscode
+dump

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,7 @@
+# Generate a new key pair with
+# node src/cli.js keypair
+# docker-compose run avalon node src/cli.js keypair
+
+NODE_OWNER=observer-node
+NODE_OWNER_PUB=25tNmyZGaKrJ8Z3oP3iyWvX6n62aBUv9QBnq4pFbYBxuK
+NODE_OWNER_PRIV=3DQwxKN2E972xTpp8agF6f2Sabm2xvKgRtCrFMNceKxA

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ logs/*
 tmptx.json
 bin
 dump
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL "project.home"="https://github.com/dtube/avalon"
 
 WORKDIR /app
 
-COPY package*.json .
+COPY package*.json ./
 RUN npm install
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,22 @@
-FROM node:latest
-LABEL "project.home"="https://github.com/nannal/avalon"
-RUN git clone git://github.com/skzap/avalon
-WORKDIR /avalon
-RUN npm install
-EXPOSE 6001
-EXPOSE 3001
+FROM node:10
+
 ENV DB_URL 'mongodb://localhost:27017'
 ENV DB_NAME 'avalon'
 ENV NODE_OWNER 'default user'
 ENV NODE_OWNER_PUB 'Invalid Key'
 ENV NODE_OWNER_PRIV 'Invalid Key'
 ENV PEERS 'ws://api.avalon.wtf:6001,ws://avalon.nannal.com:6001,ws://82.66.109.22:6001'
+
+LABEL "project.home"="https://github.com/dtube/avalon"
+
+WORKDIR /app
+
+COPY package*.json .
+RUN npm install
+
+COPY . .
+
+EXPOSE 6001
+EXPOSE 3001
+
 CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+
+services:
+  avalon:
+    build: .
+    environment:
+      DB_URL: mongodb://mongo:27017
+    volumes:
+      - .:/app
+      - /app/node_modules
+    ports:
+      - 3001:3001
+      - 6001:6001
+    restart: unless-stopped
+    command: npm start
+
+  mongo:
+    image: mongo:4.2
+    # environment:
+    #   MONGO_INITDB_ROOT_USERNAME: root
+    #   MONGO_INITDB_ROOT_PASSWORD: example

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,10 @@ services:
   avalon:
     build: .
     environment:
-      DB_URL: mongodb://mongo:27017
+      DB_URL: mongodb://mongodb:27017
+      NODE_OWNER_PUB: ${NODE_OWNER_PUB}
+      NODE_OWNER_PRIV: ${NODE_OWNER_PRIV}
+      NODE_OWNER: ${NODE_OWNER}
     volumes:
       - .:/app
       - /app/node_modules
@@ -12,10 +15,14 @@ services:
       - 3001:3001
       - 6001:6001
     restart: unless-stopped
-    command: npm start
+    command: npm run start:docker
+    depends_on:
+      - mongodb
 
-  mongo:
+  mongodb:
     image: mongo:4.2
-    # environment:
-    #   MONGO_INITDB_ROOT_USERNAME: root
-    #   MONGO_INITDB_ROOT_PASSWORD: example
+    volumes:
+      - ./scripts/restore_from_backup.sh:/docker-entrypoint-initdb.d/restore_from_backup.sh
+      - ./dump:/dump
+    restart: unless-stopped
+

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "",
   "scripts": {
     "start": "node src/main.js",
+    "start:docker": "wait-on tcp:mongodb:27017 && npm start",
     "cli": "node src/cli.js",
     "lint": "eslint 'src/*.js'",
     "compile_cli": "pkg src/cli.js --out-path bin --targets node10-linux-x64,node10-linux-x86,node10-macos-x64,node10-macos-x86",
     "compile_daemon": "pkg src/main.js --options stack-size=65500 --out-path bin --targets node10-linux-x64,node10-linux-x86,node10-macos-x64,node10-macos-x86"
-    
   },
   "dependencies": {
     "base-x": "^3.0.5",
@@ -51,6 +51,7 @@
   "devDependencies": {
     "chance": "^1.0.18",
     "eslint": "^5.16.0",
-    "javalon": "^1.0.7"
+    "javalon": "^1.0.7",
+    "wait-on": "^3.3.0"
   }
 }

--- a/scripts/restore_from_backup.sh
+++ b/scripts/restore_from_backup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ -e /dump/*.tar.gz ]; then
+  mkdir -p /tmp/dump/
+  cd /tmp/dump/
+  tar xfz /dump/*.tar.gz
+  mongo -eval "db.dropDatabase()" avalon
+  mongorestore -d avalon ./
+  rm -rf /tmp/dump
+fi


### PR DESCRIPTION
Hello,
  I have updated the Dockerfile to use v10 explicitly. I tried v12 but it failed with errors. Additionally, you can see the section:

```
COPY package*.json .
RUN npm install
```
This causes the `node_modules/` folder to be stored in its own docker layer. This layer can be cached by docker and is only rebuilt when the `package.json` file changes.

A `docker-compose.yml` file has been added which will launch its own instance of mongodb. Please note: the mongodb data can be destroyed by using the following command: `docker-compose down -v` to destroy the associated volume. Otherwise, the data will persist between restarts.

To run use: `docker-compose up`

Thank you,
  Gardner

