### PR TITLE
username existence check in cli wallet

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -303,22 +303,7 @@ program.command('vote-leader <leader>')
         writeLine('  $ vote-leader bob -F key.json -M alice')
     })
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    // error on unknown commands
+// error on unknown commands
 program.on('command:*', function () {
     writeLine('Unknown command: '+program.args[0])
     writeLine('See --help for a list of available commands.')
@@ -377,4 +362,18 @@ function verifyKeyAndUser() {
         writeLine('no user?')
         process.exit(1)
     }
+
+    // Check if account exists for username
+    let port = process.env.API_PORT || defaultPort
+    let ip = process.env.API_IP || '[::1]'
+    let protocol = process.env.API_PROTOCOL || 'http'
+    let getAccUrl = protocol + '://' + ip + ':' + port + '/accounts/' + program.me
+    fetch(getAccUrl)
+        .then((res) => {return res.json()})
+        .then((json) => {
+            if (json.length === 0) {
+                writeLine('Username doesn\'t exist. Is your node fully replayed?')
+                process.exit(1)
+            }
+        })
 }


### PR DESCRIPTION
When a node is not fully replayed, it is likely that the transacting account may not exist in the DB yet. If this is the case, it returns an invalid signature error (private key issue), which is wrong.

This fix checks the DB for account existence and returns the correct error message if the transacting account doesn't exist yet, and prompt the node owner to check if they are fully replayed or not.

Closes #33.