### PR TITLE
non-consensus improvements

### DIFF
--- a/monstache.toml
+++ b/monstache.toml
@@ -1,3 +1,3 @@
-# connection settings
-
-change-stream-namespaces = ["avalon.contents", "avalon.accounts"]
+[[script]]
+namespace = "avalon.contents"
+path = "/root/avalon/monstache_transform.js"

--- a/monstache_transform.js
+++ b/monstache_transform.js
@@ -1,0 +1,8 @@
+module.exports = function(doc) {
+    if (!doc.tags) return doc
+    var newTags = ''
+    for (var key in doc.tags)
+        newTags += ' '+key
+    doc.tags = newTags.trim()
+    return doc
+}

--- a/src/cache.js
+++ b/src/cache.js
@@ -4,9 +4,7 @@ var cache = {
     copy: {
         accounts: {},
         contents: {},
-        distributed: {},
-        changes: [],
-        inserts: []
+        distributed: {}
     },
     accounts: {},
     contents: {},
@@ -14,23 +12,28 @@ var cache = {
     changes: [],
     inserts: [],
     rollback: function() {
+        // rolling back changes from copied documents
         for (const key in cache.copy.accounts)
             cache.accounts[key] = cloneDeep(cache.copy.accounts[key])
         for (const key in cache.copy.contents)
             cache.contents[key] = cloneDeep(cache.copy.contents[key])
         for (const key in cache.copy.distributed)
             cache.distributed[key] = cloneDeep(cache.copy.distributed[key])
-        for (const key in cache.copy.changes)
-            cache.changes[key] = cloneDeep(cache.copy.changes[key])
-        for (const key in cache.copy.inserts)
-            cache.inserts[key] = cloneDeep(cache.copy.inserts[key])
         cache.copy.accounts = {}
         cache.copy.contents = {}
         cache.copy.distributed = {}
-        cache.copy.changes = []
-        cache.copy.inserts = []
+        cache.changes = []
+
+        // and discarding new inserts
+        for (let i = 0; i < cache.inserts.length; i++) {
+            var toRemove = cache.inserts[i]
+            var key = cache.keyByCollection(toRemove.collection)
+            delete cache[toRemove.collection][toRemove.document[key]]
+        }
+        cache.inserts = []
+
+        // and reset the econ data for nextBlock
         eco.nextBlock()
-        //logr.trace('Cache rollback\'d')
     },
     findOne: function(collection, query, cb) {
         if (['accounts','blocks','contents'].indexOf(collection) === -1) {
@@ -167,6 +170,7 @@ var cache = {
         cache.distributed = {}
     },
     writeToDisk: function(cb) {
+        logr.debug(cache.inserts.length+' Inserts')
         var executions = []
         // executing the inserts (new comment / new account)
         for (let i = 0; i < cache.inserts.length; i++)
@@ -191,6 +195,8 @@ var cache = {
             var key = change.query[cache.keyByCollection(collection)]
             docsToUpdate[collection][key] = cache[collection][key]
         }
+
+        logr.debug(cache.changes.length+' Updates compressed to '+Object.keys(docsToUpdate.accounts).length+' accounts, '+Object.keys(docsToUpdate.contents).length+' contents')
 
         for (const col in docsToUpdate) 
             for (const i in docsToUpdate[col]) 
@@ -224,8 +230,6 @@ var cache = {
             cache.copy.accounts = {}
             cache.copy.contents = {}
             cache.copy.distributed = {}
-            cache.copy.changes = []
-            cache.copy.inserts = []
         })
     },
     keyByCollection: function(collection) {

--- a/src/cache.js
+++ b/src/cache.js
@@ -170,7 +170,7 @@ var cache = {
         cache.distributed = {}
     },
     writeToDisk: function(cb) {
-        logr.debug(cache.inserts.length+' Inserts')
+        if (cache.inserts.length) logr.debug(cache.inserts.length+' Inserts')
         var executions = []
         // executing the inserts (new comment / new account)
         for (let i = 0; i < cache.inserts.length; i++)
@@ -196,7 +196,7 @@ var cache = {
             docsToUpdate[collection][key] = cache[collection][key]
         }
 
-        logr.debug(cache.changes.length+' Updates compressed to '+Object.keys(docsToUpdate.accounts).length+' accounts, '+Object.keys(docsToUpdate.contents).length+' contents')
+        if (cache.changes.length) logr.debug(cache.changes.length+' Updates compressed to '+Object.keys(docsToUpdate.accounts).length+' accounts, '+Object.keys(docsToUpdate.contents).length+' contents')
 
         for (const col in docsToUpdate) 
             for (const i in docsToUpdate[col]) 

--- a/src/consensus.js
+++ b/src/consensus.js
@@ -51,7 +51,7 @@ var consensus = {
             && possBlock[0] && possBlock[0].indexOf(process.env.NODE_OWNER) !== -1) {
                 // block becomes valid, we can move forward !
                 consensus.finalizing = true
-                logr.debug('CON block '+possBlock.block._id+'#'+possBlock.block.hash.substr(0,4)+' got finalized')
+                logr.trace('CON block '+possBlock.block._id+'#'+possBlock.block.hash.substr(0,4)+' got finalized')
                 chain.validateAndAddBlock(possBlock.block, false, function(err) {
                     if (err) throw err
 
@@ -106,7 +106,7 @@ var consensus = {
             consensus.possBlocks.push(possBlock)
 
             // now we verify the block is valid
-            logr.debug('CON/ New poss block '+block._id+'#'+block.hash.substr(0,4))
+            logr.trace('CON/ New poss block '+block._id+'#'+block.hash.substr(0,4))
             chain.isValidNewBlock(block, true, true, function(isValid) {
                 consensus.validating.splice(consensus.validating.indexOf(possBlock.block.hash), 1)                
                 if (!isValid) {
@@ -114,7 +114,7 @@ var consensus = {
                     logr.error('Received invalid new block', block.hash)
 
                 } else {
-                    logr.debug('CON/ Precommitting block '+block._id+'#'+block.hash.substr(0,4))
+                    logr.trace('CON/ Precommitting block '+block._id+'#'+block.hash.substr(0,4))
 
                     // precommitting ourselves
                     for (let i = 0; i < consensus.possBlocks.length; i++) 

--- a/src/transactions/comment.js
+++ b/src/transactions/comment.js
@@ -42,12 +42,13 @@ module.exports = {
                     cb(false, 'invalid tx parent comment does not exist'); return
                 }
                 cache.findOne('contents', {_id: tx.sender+'/'+tx.data.link}, function(err, content) {
-                    if (content) {
+                    if (content)
                         // user is editing an existing comment
                         if (content.pa !== tx.data.pa || content.pp !== tx.data.pp) {
                             cb(false, 'invalid tx parent comment cannot be edited'); return
-                        }
-                    } else 
+                        } else
+                            cb(true)
+                    else 
                         // it is a new comment
                         cb(true)
                     
@@ -59,7 +60,7 @@ module.exports = {
     execute: (tx, ts, cb) => {
         cache.findOne('contents', {_id: tx.sender+'/'+tx.data.link}, function(err, content) {
             if (err) throw err
-            if (content) 
+            if (content)
                 // existing content being edited
                 cache.updateOne('contents', {_id: tx.sender+'/'+tx.data.link}, {
                     $set: {json: tx.data.json}

--- a/src/transactions/comment.js
+++ b/src/transactions/comment.js
@@ -101,8 +101,8 @@ module.exports = {
                             cb(true)
                         })
                     else {
-                        rankings.new(newContent)
                         cb(true)
+                        rankings.new(newContent)
                     }
                 })
             }

--- a/src/transactions/comment.js
+++ b/src/transactions/comment.js
@@ -46,12 +46,13 @@ module.exports = {
                         // user is editing an existing comment
                         if (content.pa !== tx.data.pa || content.pp !== tx.data.pp) {
                             cb(false, 'invalid tx parent comment cannot be edited'); return
-                        } else
-                            cb(true)
-                    else 
+                        } else {
+                            // TODO Next hardfork
+                            // cb(true)
+                        }
+                    else
                         // it is a new comment
                         cb(true)
-                    
                 })
             })
         else 

--- a/src/transactions/comment.js
+++ b/src/transactions/comment.js
@@ -97,11 +97,13 @@ module.exports = {
                     if (tx.data.pa && tx.data.pp) 
                         cache.updateOne('contents', {_id: tx.data.pa+'/'+tx.data.pp}, { $push: {
                             child: [tx.sender, tx.data.link]
-                        }}, function() {})
-                    else 
+                        }}, function() {
+                            cb(true)
+                        })
+                    else {
                         rankings.new(newContent)
-                    
-                    cb(true)
+                        cb(true)
+                    }
                 })
             }
         })

--- a/src/transactions/promotedComment.js
+++ b/src/transactions/promotedComment.js
@@ -69,12 +69,14 @@ module.exports = {
                             if (tx.data.pa && tx.data.pp) 
                                 cache.updateOne('contents', {_id: tx.data.pa+'/'+tx.data.pp}, { $push: {
                                     child: [tx.sender, tx.data.link]
-                                }}, function() {})
-                            else 
+                                }}, function() {
+                                    cb(true, null, tx.data.burn)
+                                })
+                            else {
+                                // and report how much was burnt
+                                cb(true, null, tx.data.burn)
                                 rankings.new(newContent)
-                            
-                            // and report how much was burnt
-                            cb(true, null, tx.data.burn)
+                            }
                         })
                     })
                 })


### PR DESCRIPTION
This patch improves performance for observer nodes. There was a bug in the cache.js that would execute all the $set mongodb operations twice at the end of the block. It also created a bug with sub-comments, which were considered as already existing, and thus did not push the video id to the `child` field which is used by the API to generate the comments tree.

Also added a monstache middleware, as elasticsearch doesn't like the way avalon stores tags in mongodb.