### PR TITLE
fix missing removeListener() callback in API

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -98,8 +98,9 @@ var http = {
                     transaction.addToPool([tx])
 
                     var transactTimeout = setTimeout(function() {
-                        transaction.eventConfirmation.removeListener(tx.hash)
-                        res.status(408).send({error: 'transaction timeout'})
+                        transaction.eventConfirmation.removeListener(tx.hash,() => {
+                            res.status(408).send({error: 'transaction timeout'})
+                        })
                     }, timeout_transact_async)
 
                     transaction.eventConfirmation.addListener(tx.hash, function() {

--- a/src/http.js
+++ b/src/http.js
@@ -98,9 +98,8 @@ var http = {
                     transaction.addToPool([tx])
 
                     var transactTimeout = setTimeout(function() {
-                        transaction.eventConfirmation.removeListener(tx.hash,() => {
-                            res.status(408).send({error: 'transaction timeout'})
-                        })
+                        transaction.eventConfirmation.removeListener(tx.hash,() => {})
+                        res.status(408).send({error: 'transaction timeout'})
                     }, timeout_transact_async)
 
                     transaction.eventConfirmation.addListener(tx.hash, function() {


### PR DESCRIPTION
When there is a transaction timeout error, it should properly send a response instead of crashing the API node. The crash is due to a missing callback function in the removeListener() method call in /transactWaitConfirm API.