### PR TITLE
Nodejs v14 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "adm-zip": "^0.4.14",
-    "base-x": "^3.0.5",
+    "base-x": "^3.0.8",
     "body-parser": "^1.15.2",
     "clone-deep": "^4.0.1",
     "commander": "^2.20.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "oembed-parser": "^1.2.2",
     "open-graph-scraper": "^3.6.1",
     "run-series": "^1.1.8",
-    "secp256k1": "^3.8.0",
+    "secp256k1": "^4.0.2",
     "sha256-file": "^1.0.0",
     "signale": "^1.4.0",
     "simple-youtube-api": "^5.2.1",

--- a/src/chain.js
+++ b/src/chain.js
@@ -88,7 +88,7 @@ chain = {
     },
     hashAndSignBlock: (block) => {
         var nextHash = chain.calculateHash(block._id, block.phash, block.timestamp, block.txs, block.miner, block.missedBy, block.distributed, block.burned)
-        var signature = secp256k1.sign(Buffer.from(nextHash, 'hex'), bs58.decode(process.env.NODE_OWNER_PRIV))
+        var signature = secp256k1.ecdsaSign(Buffer.from(nextHash, 'hex'), bs58.decode(process.env.NODE_OWNER_PRIV))
         signature = bs58.encode(signature.signature)
         return new Block(block._id, block.phash, block.timestamp, block.txs, block.miner, block.missedBy, block.distributed, block.burned, signature, nextHash)
         
@@ -367,7 +367,7 @@ chain = {
                 var bufferHash = Buffer.from(hash, 'hex')
                 var b58sign = bs58.decode(sign)
                 var b58pub = bs58.decode(allowedPubKeys[i])
-                if (secp256k1.verify(bufferHash, b58sign, b58pub)) {
+                if (secp256k1.ecdsaVerify(b58sign, bufferHash, b58pub)) {
                     cb(account)
                     return
                 }

--- a/src/clicmds.js
+++ b/src/clicmds.js
@@ -18,7 +18,7 @@ let sign = (privKey, sender, tx) => {
     var rawPriv = bs58.decode(privKey)
 
     // sign the tx
-    var signature = secp256k1.sign(Buffer.from(tx.hash, 'hex'), rawPriv)
+    var signature = secp256k1.ecdsaSign(Buffer.from(tx.hash, 'hex'), rawPriv)
 
     // convert signature to base58
     tx.signature = bs58.encode(signature.signature)

--- a/src/consensus.js
+++ b/src/consensus.js
@@ -225,7 +225,7 @@ var consensus = {
     },
     signMessage: (message) => {
         var hash = CryptoJS.SHA256(JSON.stringify(message)).toString()
-        var signature = secp256k1.sign(Buffer.from(hash, 'hex'), bs58.decode(process.env.NODE_OWNER_PRIV))
+        var signature = secp256k1.ecdsaSign(Buffer.from(hash, 'hex'), bs58.decode(process.env.NODE_OWNER_PRIV))
         signature = bs58.encode(signature.signature)
         message.s = {
             n: process.env.NODE_OWNER,
@@ -244,9 +244,9 @@ var consensus = {
         delete tmpMess.s
         var hash = CryptoJS.SHA256(JSON.stringify(tmpMess)).toString()
         var pub = consensus.getActiveLeaderKey(name)
-        if (pub && secp256k1.verify(
-            Buffer.from(hash, 'hex'),
+        if (pub && secp256k1.ecdsaVerify(
             bs58.decode(sign),
+            Buffer.from(hash, 'hex'),
             bs58.decode(pub))) {
             cb(true)
             return

--- a/src/main.js
+++ b/src/main.js
@@ -13,11 +13,10 @@ rankings = require('./rankings.js')
 consensus = require('./consensus')
 
 // verify node version
-const nodeV = 14
-const versionRegex = new RegExp(`^${nodeV}\\..*`)
-const versionCorrect = process.versions.node.match(versionRegex)
-if (!versionCorrect) {
-    logr.fatal('Wrong NodeJS version. v10 is required.')
+const minNodeV = 10
+const currentNodeV = parseInt(process.versions.node.split('.')[0])
+if (currentNodeV < minNodeV) {
+    logr.fatal('Wrong NodeJS version. Minimum v10 is required.')
     process.exit(1)
 } else logr.info('Correctly using NodeJS v'+process.versions.node)
 

--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,7 @@ rankings = require('./rankings.js')
 consensus = require('./consensus')
 
 // verify node version
-const nodeV = 10
+const nodeV = 14
 const versionRegex = new RegExp(`^${nodeV}\\..*`)
 const versionCorrect = process.versions.node.match(versionRegex)
 if (!versionCorrect) {

--- a/src/p2p.js
+++ b/src/p2p.js
@@ -156,7 +156,7 @@ var p2p = {
                     nodeId: message.d.nodeId
                 }
 
-                var sign = secp256k1.sign(Buffer.from(message.d.random, 'hex'), bs58.decode(p2p.nodeId.priv))
+                var sign = secp256k1.ecdsaSign(Buffer.from(message.d.random, 'hex'), bs58.decode(p2p.nodeId.priv))
                 sign = bs58.encode(sign.signature)
 
                 var d = {
@@ -181,9 +181,9 @@ var p2p = {
                     if (!challengeHash)
                         return
                     try {
-                        var isValidSignature = secp256k1.verify(
-                            Buffer.from(challengeHash, 'hex'),
+                        var isValidSignature = secp256k1.ecdsaVerify(
                             bs58.decode(message.d.sign),
+                            Buffer.from(challengeHash, 'hex'),
                             bs58.decode(nodeId))
                         if (!isValidSignature) {
                             logr.warn('Wrong NODE_STATUS signature, disconnecting')


### PR DESCRIPTION
Added compatibility for newer NodeJS versions as v10 will no longer be supported in less than 8 months. Tested with NodeJS v12 and v14 in observer and block production.