### PR TITLE
/supply API

### DIFF
--- a/doc/debian-10.md
+++ b/doc/debian-10.md
@@ -1,3 +1,4 @@
+```
 #new node install procedure from debian 10:
 
 sudo apt-get update
@@ -5,7 +6,6 @@ sudo apt-get upgrade
 sudo apt-get install git wget tmux htop jq
 git clone https://github.com/dtube/avalon.git
 cd avalon/
-git checkout develop
 
 #node+npm
 sudo apt-get install nodejs npm
@@ -23,3 +23,4 @@ sudo apt-get install -y mongodb-org
 
 #npm packages
 npm install
+```

--- a/src/http.js
+++ b/src/http.js
@@ -51,7 +51,7 @@ var http = {
         app.get('/supply', (req,res) => {
             let executions = [
                 (cb) => db.collection('accounts').aggregate([{$group:{_id: 0, total: {$sum: "$balance"}}}]).toArray((e,r) => cb(e,r)),
-                (cb) => db.collection('contents').aggregate([{$unwind: "$votes"},{$group:{_id: 0, total: {$sum: "$votes.claimable"}}}]).toArray((e,r) => cb(e,r))
+                (cb) => db.collection('contents').aggregate([{$unwind: "$votes"},{$match:{"votes.claimed":{$exists:false}}},{$group:{_id: 0, total: {$sum: "$votes.claimable"}}}]).toArray((e,r) => cb(e,r))
             ]
 
             series(executions,(e,r) => {

--- a/src/http.js
+++ b/src/http.js
@@ -47,6 +47,24 @@ var http = {
             else res.send({})
         })
 
+        // get supply info
+        app.get('/supply', (req,res) => {
+            let executions = [
+                (cb) => db.collection('accounts').aggregate([{$group:{_id: 0, total: {$sum: "$balance"}}}]).toArray((e,r) => cb(e,r)),
+                (cb) => db.collection('contents').aggregate([{$unwind: "$votes"},{$group:{_id: 0, total: {$sum: "$votes.claimable"}}}]).toArray((e,r) => cb(e,r))
+            ]
+
+            series(executions,(e,r) => {
+                if (e)
+                    return res.sendStatus(500)
+                res.send({
+                    circulating: r[0][0].total,
+                    unclaimed: r[1][0].total,
+                    total: r[0][0].total + r[1][0].total
+                })
+            })
+        })
+
         // generate a new key pair
         app.get('/newKeyPair', (req, res) => {
             res.send(chain.getNewKeyPair())


### PR DESCRIPTION
Added /supply GET API to obtain the current circulating and total supply, plus total unclaimed rewards. Useful for block explorers and crypto market aggregators.

Example response:
```
{
    "circulating": 13051866999,
    "unclaimed": 139636161.6675,
    "total": 13191503160.6675
}
```