### PR TITLE
Add /tx API for querying tx by hash

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -29,6 +29,18 @@ var http = {
                 res.send(block)
             })
         })
+
+        // query single transaction by hash
+        app.get('/tx/:txhash',(req,res) => {
+            db.collection('blocks').findOne({ "txs.hash": req.params.txhash }, { projection: { _id: 0, txs: { $elemMatch: { hash: req.params.txhash}}}},(error,tx) => {
+                if (error)
+                    res.status(500).send(error)
+                else if (tx && tx.txs)
+                    res.send(tx.txs[0])
+                else
+                    res.status(404).send({error: 'transaction not found'})
+            })
+        })
         
         // count how many blocks are in the node
         app.get('/count', (req, res) => {


### PR DESCRIPTION
This add /tx/:txhash API that allows querying a single transaction by its hash.

Example:
```
$ curl https://avalon.oneloved.tube/tx/98b1844e4ebef38a71f8a29e37daadf8e4e6c7ae7d6c0116ed556bb39f6590a9 | jq

{
  "type": 1,
  "data": {
    "target": "zurich"
  },
  "sender": "dtube",
  "ts": 1601557504677,
  "hash": "98b1844e4ebef38a71f8a29e37daadf8e4e6c7ae7d6c0116ed556bb39f6590a9",
  "signature": "34BHR6F5uPGWtnD6gcxV68jVuqiRxQJyq4LZLtvSQ5zEfFeL3Svhi76FEF359ziTP9dFhVQGeqemsoLQga1Z7jHP"
}
```