### PR TITLE
Hard Fork on block #1,000,090

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -116,6 +116,11 @@ var config = {
             // the number of ms needed for 0.01 DTC to generate 1 vt
             vtGrowth: 360000000, // +1 vt per hour per DTC (3600 * 1000 * 100)
             vtPerBurn: 6 // can be updated in the future to modify incentives
+        },
+        1000090: {
+            leaders: 13,
+            leaderRewardVT: 100,
+            vtPerBurn: 44
         }
     },
     read: (blockNum) => {


### PR DESCRIPTION
As talked about on the discord, here comes a config change for the chain, applying on block 1,000,090 (around november 6th if chain runs normally at 1 block / 3 sec)

It changes:

* Total number of active leaders in consensus increased from **10** to **13**
* Voting Power rewards for mining a block reduced from **500** to **100**
* Promotion Burning efficiency improved from **600** VP / DTC to **4400** VP / DTC

The rationale for leaders is simple. We can have more active leaders now since more people have showed up after main-net launch. The active leaders are earning too much voting power at the moment compared to normal users. So effectively, the power generated by each active leader will get diminshed by a factor of 6.5 in total.

The 'burn to promote content' feature is currently underused, and seems very under-efficient. 600 VP / DTC was equivalent to getting 25 days worth of VP generation for a burn. 4400 VP is equivalent to 6 months generation now and seems like a better incentive for people to burn. We will probably re-tune this number in the future depending on if not-enough or too-many people burn.

Please show your approval for this code change on GitHub with thumbs-up or thumbs-down so I can merge it quickly so that we can all update our nodes quickly too.