### PR TITLE
Rebuild Optimizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "lint": "eslint 'src/*.js'"
   },
   "dependencies": {
-    "adm-zip": "^0.4.14",
     "base-x": "^3.0.8",
     "body-parser": "^1.15.2",
     "clone-deep": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node-fetch": "^2.3.0",
     "oembed-parser": "^1.2.2",
     "open-graph-scraper": "^3.6.1",
-    "run-series": "^1.1.8",
+    "run-parallel": "^1.1.10",
     "secp256k1": "^4.0.2",
     "sha256-file": "^1.0.0",
     "signale": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "oembed-parser": "^1.2.2",
     "open-graph-scraper": "^3.6.1",
     "run-parallel": "^1.1.10",
+    "run-series": "^1.1.9",
     "secp256k1": "^4.0.2",
     "sha256-file": "^1.0.0",
     "signale": "^1.4.0",

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -30,11 +30,12 @@ export WARN_SLOW_EXEC=5
 export LOG_LEVEL=info
 
 # groups blocks during replay output to lower screen spam
-export REPLAY_OUTPUT=100
+export REPLAY_OUTPUT=10000
 
 # Rebuild chain state from dump, verifying every block and transactions
 # Do not forget to comment this out after rebuild
 #export REBUILD_STATE=1
+#export REBUILD_IN_MEMORY=1
 #export REBUILD_RESUME_BLK=
 
 # default peers to connect with on startup
@@ -45,5 +46,8 @@ export MAX_PEERS=20
 export NODE_OWNER=dtube
 export NODE_OWNER_PUB=dTuBhkU6SUx9JEx1f4YEt34X9sC7QGso2dSrqE8eJyfz
 export NODE_OWNER_PRIV=34EpMEDFJwKbxaF7FhhLyEe3AhpM4dwHMLVfs4JyRto5
+
+# Memory limit for in-memory rebuild (in MB)
+export NODE_OPTIONS=--max_old_space_size=8192
 
 node --stack-size=65500 src/main

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -35,7 +35,7 @@ export REPLAY_OUTPUT=10000
 # Rebuild chain state from dump, verifying every block and transactions
 # Do not forget to comment this out after rebuild
 #export REBUILD_STATE=1
-#export REBUILD_IN_MEMORY=1
+#export REBUILD_WRITE_INTERVAL=
 #export REBUILD_RESUME_BLK=
 
 # default peers to connect with on startup

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -35,7 +35,7 @@ export REPLAY_OUTPUT=10000
 # Rebuild chain state from dump, verifying every block and transactions
 # Do not forget to comment this out after rebuild
 #export REBUILD_STATE=1
-#export REBUILD_WRITE_INTERVAL=
+#export REBUILD_WRITE_INTERVAL=10000
 #export REBUILD_RESUME_BLK=
 
 # default peers to connect with on startup

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -16,6 +16,7 @@
 # Enable more modules
 #export NOTIFICATIONS=1
 #export RANKINGS=1
+#export CONTENTS=1
 
 # Cache warmup option
 export WARMUP_ACCOUNTS=100000

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,4 +1,4 @@
-const series = require('run-series')
+const parallel = require('run-parallel')
 const cloneDeep = require('clone-deep')
 var cache = {
     copy: {
@@ -153,7 +153,7 @@ var cache = {
                 })
             })
         
-        series(executions, function(err, results) {
+        parallel(executions, function(err, results) {
             cb(err, results)
         })
     },
@@ -228,7 +228,7 @@ var cache = {
         // }
         
         var timeBefore = new Date().getTime()
-        series(executions, function(err, results) {
+        parallel(executions, function(err, results) {
             logr.debug(executions.length+' mongo queries executed in '+(new Date().getTime()-timeBefore)+'ms')
             cache.changes = []
             cache.inserts = []

--- a/src/cache.js
+++ b/src/cache.js
@@ -230,12 +230,12 @@ var cache = {
         var timeBefore = new Date().getTime()
         series(executions, function(err, results) {
             logr.debug(executions.length+' mongo queries executed in '+(new Date().getTime()-timeBefore)+'ms')
-            cb(err, results)
             cache.changes = []
             cache.inserts = []
             cache.copy.accounts = {}
             cache.copy.contents = {}
             cache.copy.distributed = {}
+            cb(err, results)
         })
     },
     keyByCollection: function(collection) {

--- a/src/cache.js
+++ b/src/cache.js
@@ -269,7 +269,7 @@ var cache = {
             cb(err, results)
         })
     },
-    processRebuildOps: (cb) => {
+    processRebuildOps: (cb,writeToDisk) => {
         for (let i in cache.inserts)
             cache.rebuild.inserts.push(cache.inserts[i])
         for (let i in cache.changes)
@@ -279,7 +279,10 @@ var cache = {
         cache.copy.accounts = {}
         cache.copy.contents = {}
         cache.copy.distributed = {}
-        cb()
+        if (writeToDisk)
+            cache.writeToDisk(cb,true)
+        else
+            cb()
     },
     keyByCollection: function(collection) {
         switch (collection) {

--- a/src/chain.js
+++ b/src/chain.js
@@ -753,9 +753,6 @@ chain = {
     },
     batchLoadBlocks: (blockNum,cb) => {
         if (chain.blocksToRebuild.length == 0) {
-            let batchBlockRange = []
-            for (let i = blockNum; i < blockNum+max_batch_blocks; i++)
-                batchBlockRange.push(i)
             db.collection('blocks').find({_id: { $gte: blockNum, $lt: blockNum+max_batch_blocks }}).toArray((e,blocks) => {
                 if (e) throw e
                 if (blocks) chain.blocksToRebuild = blocks

--- a/src/chain.js
+++ b/src/chain.js
@@ -2,13 +2,13 @@ var CryptoJS = require('crypto-js')
 const { randomBytes } = require('crypto')
 const secp256k1 = require('secp256k1')
 const bs58 = require('base-x')(config.b58Alphabet)
-const parallel = require('run-parallel')
+const series = require('run-series')
 const cloneDeep = require('clone-deep')
 const transaction = require('./transaction.js')
 const notifications = require('./notifications.js')
-var GrowInt = require('growint')
-var default_replay_output = 100
-var replay_output = process.env.REPLAY_OUTPUT || default_replay_output
+const GrowInt = require('growint')
+const default_replay_output = 100
+const replay_output = process.env.REPLAY_OUTPUT || default_replay_output
 const max_batch_blocks = 10000
 
 class Block {
@@ -574,7 +574,7 @@ chain = {
             })
         
         var blockTimeBefore = new Date().getTime()
-        parallel(executions, function(err, results) {
+        series(executions, function(err, results) {
             var string = 'executed'
             if(revalidate) string = 'validated & '+string
             logr.debug('Block '+string+' in '+(new Date().getTime()-blockTimeBefore)+'ms')

--- a/src/chain.js
+++ b/src/chain.js
@@ -781,7 +781,8 @@ chain = {
                     eco.nextBlock()
                     chain.cleanMemory()
 
-                    let writeOp = (process.env.REBUILD_IN_MEMORY === '1' || process.env.REBUILD_IN_MEMORY === 1) ? 'processRebuildOps' : 'writeToDisk'
+                    let writeInterval = parseInt(process.env.REBUILD_WRITE_INTERVAL)
+                    let writeOp = (!isNaN(writeInterval) && writeInterval > 1 && blockToRebuild._id % writeInterval === 0) ? 'processRebuildOps' : 'writeToDisk'
 
                     cache[writeOp](() => {
                         if (blockToRebuild._id % config.leaders === 0)

--- a/src/chain.js
+++ b/src/chain.js
@@ -756,10 +756,10 @@ chain = {
                 return cb(null,blockNum)
             
             // Validate block and transactions, then execute them
-            chain.isValidNewBlock(blockToRebuild,true,true,(isValid) => {
+            chain.isValidNewBlock(blockToRebuild,true,false,(isValid) => {
                 if (!isValid)
                     return cb(true, blockNum)
-                chain.executeBlockTransactions(blockToRebuild,false,true,(validTxs,dist,burn) => {
+                chain.executeBlockTransactions(blockToRebuild,true,true,(validTxs,dist,burn) => {
                     // if any transaction is wrong, thats a fatal error
                     // transactions should have been verified in isValidNewBlock
                     if (blockToRebuild.txs.length !== validTxs.length) {

--- a/src/chain.js
+++ b/src/chain.js
@@ -494,13 +494,13 @@ chain = {
                 
 
         if (minerPriority === 0) {
-            logr.debug('unauthorized miner')
+            logr.error('unauthorized miner')
             cb(false); return
         }
 
         // check if new block isnt too early
         if (newBlock.timestamp - previousBlock.timestamp < minerPriority*config.blockTime) {
-            logr.debug('block too early for miner with priority #'+minerPriority)
+            logr.error('block too early for miner with priority #'+minerPriority)
             cb(false); return
         }
 
@@ -631,7 +631,8 @@ chain = {
     },
     generateLeaders: (withLeaderPub, limit, start) => {
         var leaders = []
-        for (const key in cache.accounts) {
+        let leaderAccs = withLeaderPub ? cache.leaders : cache.accounts
+        for (const key in leaderAccs) {
             if (!cache.accounts[key].node_appr || cache.accounts[key].node_appr <= 0)
                 continue
             if (withLeaderPub && !cache.accounts[key].pub_leader)
@@ -651,32 +652,6 @@ chain = {
             return b.node_appr - a.node_appr
         })
         return leaders.slice(start, limit)
-
-        // the old mongodb query used instead
-        // var query = {
-        //     $and: [{
-        //         pub_leader: {$exists: true}
-        //     }, {
-        //         node_appr: {$gt: 0}
-        //     }]
-        // }
-        // if (!withLeaderPub)
-        //     query['$and'].splice(0,1)
-        // db.collection('accounts').find(query,{
-        //     sort: {node_appr: -1, name: -1},
-        //     limit: limit
-        // }).project({
-        //     name: 1,
-        //     pub: 1,
-        //     pub_leader: 1,
-        //     balance: 1,
-        //     approves: 1,
-        //     node_appr: 1,
-        //     json: 1,
-        // }).toArray(function(err, accounts) {
-        //     if (err) throw err
-        //     cb(accounts)
-        // })
     },
     leaderRewards: (name, ts, cb) => {
         // rewards leaders with 'free' voting power in the network

--- a/src/chain.js
+++ b/src/chain.js
@@ -782,7 +782,8 @@ chain = {
                     chain.cleanMemory()
 
                     let writeInterval = parseInt(process.env.REBUILD_WRITE_INTERVAL)
-                    let writeOp = (!isNaN(writeInterval) && writeInterval > 1 && blockToRebuild._id % writeInterval === 0) ? 'processRebuildOps' : 'writeToDisk'
+                    let writeOp = (!isNaN(writeInterval) && writeInterval > 1) ? 'processRebuildOps' : 'writeToDisk'
+                    let writeBool = (writeOp === 'processRebuildOps' && blockToRebuild._id % writeInterval === 0) ? true : false
 
                     cache[writeOp](() => {
                         if (blockToRebuild._id % config.leaders === 0)
@@ -807,7 +808,7 @@ chain = {
                             // next block
                             chain.rebuildState(blockNum+1, cb)
                         }
-                    })
+                    },writeBool)
                 })
             })
         })

--- a/src/chain.js
+++ b/src/chain.js
@@ -2,14 +2,14 @@ var CryptoJS = require('crypto-js')
 const { randomBytes } = require('crypto')
 const secp256k1 = require('secp256k1')
 const bs58 = require('base-x')(config.b58Alphabet)
-const series = require('run-series')
+const parallel = require('run-parallel')
 const cloneDeep = require('clone-deep')
 const transaction = require('./transaction.js')
 const notifications = require('./notifications.js')
 var GrowInt = require('growint')
 var default_replay_output = 100
 var replay_output = process.env.REPLAY_OUTPUT || default_replay_output
-const max_batch_blocks = 1000
+const max_batch_blocks = 10000
 
 class Block {
     constructor(index, phash, timestamp, txs, miner, missedBy, dist, burn, signature, hash) {
@@ -574,7 +574,7 @@ chain = {
             })
         
         var blockTimeBefore = new Date().getTime()
-        series(executions, function(err, results) {
+        parallel(executions, function(err, results) {
             var string = 'executed'
             if(revalidate) string = 'validated & '+string
             logr.debug('Block '+string+' in '+(new Date().getTime()-blockTimeBefore)+'ms')
@@ -811,7 +811,6 @@ chain = {
                     eco.nextBlock()
                     chain.cleanMemory()
 
-                    // OPTIMIZATION: Write to disk on interruption/completion
                     cache.writeToDisk(() => {
                         if (blockToRebuild._id % config.leaders === 0) 
                             chain.minerSchedule(blockToRebuild, function(minerSchedule) {

--- a/src/chain.js
+++ b/src/chain.js
@@ -782,10 +782,10 @@ chain = {
                     chain.cleanMemory()
 
                     let writeInterval = parseInt(process.env.REBUILD_WRITE_INTERVAL)
-                    let writeOp = (!isNaN(writeInterval) && writeInterval > 1) ? 'processRebuildOps' : 'writeToDisk'
-                    let writeBool = (writeOp === 'processRebuildOps' && blockToRebuild._id % writeInterval === 0) ? true : false
+                    if (isNaN(writeInterval) || writeInterval < 1)
+                        writeInterval = 10000
 
-                    cache[writeOp](() => {
+                    cache.processRebuildOps(() => {
                         if (blockToRebuild._id % config.leaders === 0)
                             chain.minerSchedule(blockToRebuild, function(minerSchedule) {
                                 chain.schedule = minerSchedule
@@ -808,7 +808,7 @@ chain = {
                             // next block
                             chain.rebuildState(blockNum+1, cb)
                         }
-                    },writeBool)
+                    }, blockToRebuild._id % writeInterval === 0)
                 })
             })
         })

--- a/src/chain.js
+++ b/src/chain.js
@@ -778,14 +778,12 @@ chain = {
             return
         }
 
-        // OPTIMIZATION: Load blocks in parallel
         chain.batchLoadBlocks(blockNum,(blockToRebuild) => {
             if (!blockToRebuild)
                 // Rebuild is complete
                 return cb(null,blockNum)
             
             // Validate block and transactions, then execute them
-            // OPTIMIZATION: Validate blocks and block transactions in parallel
             chain.isValidNewBlock(blockToRebuild,true,true,(isValid) => {
                 if (!isValid)
                     return cb(true, blockNum)

--- a/src/economics.js
+++ b/src/economics.js
@@ -1,4 +1,3 @@
-const series = require('run-series')
 const one_day = 86400000
 const one_hour = 3600000
 const one_minute = 60000

--- a/src/http.js
+++ b/src/http.js
@@ -7,7 +7,7 @@ const yt_key = process.env.YT_API_KEY || 'NO_KEY'
 const yt = new YT(yt_key)
 const { extract } = require('oembed-parser')
 const ogs = require('open-graph-scraper')
-const series = require('run-series')
+const parallel = require('run-parallel')
 const transaction = require('./transaction.js')
 const timeout_transact_async = 7500
 
@@ -54,7 +54,7 @@ var http = {
                 (cb) => db.collection('contents').aggregate([{ $unwind: "$votes" }, { $match: { "votes.claimed": { $exists: false } } }, { $group: { _id: 0, total: { $sum: "$votes.claimable" } } }]).toArray((e, r) => cb(e, r))
             ]
 
-            series(executions, (e, r) => {
+            parallel(executions, (e, r) => {
                 if (e)
                     return res.sendStatus(500)
 
@@ -691,7 +691,7 @@ var http = {
                             i++
                         })
 
-                    series(executions, function (err, results) {
+                    parallel(executions, function (err, results) {
                         if (err) throw err
                         cb(null, results)
                     })

--- a/src/main.js
+++ b/src/main.js
@@ -85,7 +85,7 @@ function startRebuild(startBlock) {
             logr.info('Rebuild data written to disk in ' + (new Date().getTime() - cacheWriteStart) + ' ms')
             if (chain.shuttingDown) return process.exit(0)
             startDaemon()
-        })
+        },true)
     })
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -117,7 +117,7 @@ process.on('SIGINT', function() {
     if (typeof closing !== 'undefined') return
     closing = true
     chain.shuttingDown = true
-    if (!erroredRebuild || chain.restoredBlocks && chain.getLatestBlock()._id < chain.restoredBlocks) return
+    if (!erroredRebuild && chain.restoredBlocks && chain.getLatestBlock()._id < chain.restoredBlocks) return
     logr.warn('Waiting '+config.blockTime+' ms before shut down...')
     setTimeout(function() {
         logr.info('Avalon exitted safely')

--- a/src/main.js
+++ b/src/main.js
@@ -69,6 +69,7 @@ mongo.init(function() {
 
 function startRebuild(startBlock) {
     let rebuildStartTime = new Date().getTime()
+    chain.lastRebuildOutput = rebuildStartTime
     chain.rebuildState(startBlock,(e,headBlockNum) => {
         if (e)
             return logr.error('Error rebuilding chain at block',headBlockNum, e)

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -3,7 +3,7 @@ var isEnabled = process.env.NOTIFICATIONS || false
 
 notifications = {
     processBlock: (block) => {
-        if (!isEnabled) return
+        if (!isEnabled || (chain.restoredBlocks && chain.getLatestBlock()._id + config.notifPurge * config.notifPurgeAfter < chain.restoredBlocks)) return
 
         if (block._id % config.notifPurge === 0)
             notifications.purgeOld(block)

--- a/src/transactions/comment.js
+++ b/src/transactions/comment.js
@@ -88,12 +88,10 @@ module.exports = {
                     votes: [vote],
                     ts: ts
                 }
-                if (tx.data.tag)  {
+                if (tx.data.tag && process.env.CONTENTS == '1')  {
                     vote.tag = tx.data.tag
-                    if (process.env.CONTENTS == '1') {
-                        newContent.tags = {}
-                        newContent.tags[tx.data.tag] = Math.abs(vote.vt)
-                    }
+                    newContent.tags = {}
+                    newContent.tags[tx.data.tag] = Math.abs(vote.vt)
                 }
                 cache.insertOne('contents', newContent, function(){
                     // monetary distribution (curation rewards)

--- a/src/transactions/comment.js
+++ b/src/transactions/comment.js
@@ -56,7 +56,7 @@ module.exports = {
     execute: (tx, ts, cb) => {
         cache.findOne('contents', {_id: tx.sender+'/'+tx.data.link}, function(err, content) {
             if (err) throw err
-            if (content && process.env.CONTENT == '1')
+            if (content && process.env.CONTENTS == '1')
                 // existing content being edited
                 cache.updateOne('contents', {_id: tx.sender+'/'+tx.data.link}, {
                     $set: {json: tx.data.json}
@@ -83,14 +83,14 @@ module.exports = {
                     link: tx.data.link,
                     pa: tx.data.pa,
                     pp: tx.data.pp,
-                    json: process.env.CONTENT == '1' ? tx.data.json : {},
+                    json: process.env.CONTENTS == '1' ? tx.data.json : {},
                     child: [],
                     votes: [vote],
                     ts: ts
                 }
                 if (tx.data.tag)  {
                     vote.tag = tx.data.tag
-                    if (process.env.CONTENT == '1') {
+                    if (process.env.CONTENTS == '1') {
                         newContent.tags = {}
                         newContent.tags[tx.data.tag] = Math.abs(vote.vt)
                     }
@@ -98,7 +98,7 @@ module.exports = {
                 cache.insertOne('contents', newContent, function(){
                     // monetary distribution (curation rewards)
                     eco.curation(tx.sender, tx.data.link, function(distCurators, distMaster) {
-                        if (tx.data.pa && tx.data.pp && process.env.CONTENT == '1') 
+                        if (tx.data.pa && tx.data.pp && process.env.CONTENTS == '1') 
                             cache.updateOne('contents', {_id: tx.data.pa+'/'+tx.data.pp}, { $push: {
                                 child: [tx.sender, tx.data.link]
                             }}, function() {

--- a/src/transactions/comment.js
+++ b/src/transactions/comment.js
@@ -56,7 +56,7 @@ module.exports = {
     execute: (tx, ts, cb) => {
         cache.findOne('contents', {_id: tx.sender+'/'+tx.data.link}, function(err, content) {
             if (err) throw err
-            if (content)
+            if (content && process.env.CONTENT == '1')
                 // existing content being edited
                 cache.updateOne('contents', {_id: tx.sender+'/'+tx.data.link}, {
                     $set: {json: tx.data.json}
@@ -66,7 +66,10 @@ module.exports = {
                         rankings.new(content)
                     cb(true)
                 })
-            else {
+            else if (content) {
+                // existing content being edited but node running without CONTENT module
+                cb(true)
+            } else {
                 // new content
                 var vote = {
                     u: tx.sender,
@@ -80,20 +83,22 @@ module.exports = {
                     link: tx.data.link,
                     pa: tx.data.pa,
                     pp: tx.data.pp,
-                    json: tx.data.json,
+                    json: process.env.CONTENT == '1' ? tx.data.json : {},
                     child: [],
                     votes: [vote],
                     ts: ts
                 }
                 if (tx.data.tag)  {
-                    if (tx.data.tag) vote.tag = tx.data.tag
-                    newContent.tags = {}
-                    newContent.tags[tx.data.tag] = Math.abs(vote.vt)
+                    vote.tag = tx.data.tag
+                    if (process.env.CONTENT == '1') {
+                        newContent.tags = {}
+                        newContent.tags[tx.data.tag] = Math.abs(vote.vt)
+                    }
                 }
                 cache.insertOne('contents', newContent, function(){
                     // monetary distribution (curation rewards)
                     eco.curation(tx.sender, tx.data.link, function(distCurators, distMaster) {
-                        if (tx.data.pa && tx.data.pp) 
+                        if (tx.data.pa && tx.data.pp && process.env.CONTENT == '1') 
                             cache.updateOne('contents', {_id: tx.data.pa+'/'+tx.data.pp}, { $push: {
                                 child: [tx.sender, tx.data.link]
                             }}, function() {
@@ -102,7 +107,7 @@ module.exports = {
                         else {
                             // and report how much was burnt
                             cb(true, distCurators+distMaster, tx.data.burn)
-                            rankings.new(newContent)
+                            if (!tx.data.pa || !tx.data.pp) rankings.new(newContent)
                         }
                     })                    
                 })

--- a/src/transactions/enableNode.js
+++ b/src/transactions/enableNode.js
@@ -12,6 +12,7 @@ module.exports = {
             },{ $set: {
                 pub_leader: tx.data.pub
             }}, function(){
+                cache.addLeader(tx.sender)
                 cb(true)
             })
         else
@@ -20,6 +21,7 @@ module.exports = {
             },{ $unset: {
                 pub_leader: ''
             }}, function(){
+                cache.removeLeader(tx.sender)
                 cb(true)
             })
     }

--- a/src/transactions/promotedComment.js
+++ b/src/transactions/promotedComment.js
@@ -49,14 +49,14 @@ module.exports = {
             link: tx.data.link,
             pa: tx.data.pa,
             pp: tx.data.pp,
-            json: process.env.CONTENT == '1' ? tx.data.json : {},
+            json: process.env.CONTENTS == '1' ? tx.data.json : {},
             child: [],
             votes: [superVote],
             ts: ts
         }
         if (tx.data.tag)  {
             superVote.tag = tx.data.tag
-            if (process.env.CONTENT == '1') {
+            if (process.env.CONTENTS == '1') {
                 newContent.tags = {}
                 newContent.tags[tx.data.tag] = Math.abs(superVote.vt)
             }
@@ -70,7 +70,7 @@ module.exports = {
                         // insert content+vote into db
                         cache.insertOne('contents', newContent, function(){
                             eco.curation(tx.sender, tx.data.link, function(distCurators, distMaster) {
-                                if (tx.data.pa && tx.data.pp && process.env.CONTENT == '1')
+                                if (tx.data.pa && tx.data.pp && process.env.CONTENTS == '1')
                                     cache.updateOne('contents', {_id: tx.data.pa+'/'+tx.data.pp}, { $push: {
                                         child: [tx.sender, tx.data.link]
                                     }}, function() {

--- a/src/transactions/promotedComment.js
+++ b/src/transactions/promotedComment.js
@@ -49,15 +49,17 @@ module.exports = {
             link: tx.data.link,
             pa: tx.data.pa,
             pp: tx.data.pp,
-            json: tx.data.json,
+            json: process.env.CONTENT == '1' ? tx.data.json : {},
             child: [],
             votes: [superVote],
             ts: ts
         }
         if (tx.data.tag)  {
-            if (tx.data.tag) superVote.tag = tx.data.tag
-            newContent.tags = {}
-            newContent.tags[tx.data.tag] = Math.abs(superVote.vt)
+            superVote.tag = tx.data.tag
+            if (process.env.CONTENT == '1') {
+                newContent.tags = {}
+                newContent.tags[tx.data.tag] = Math.abs(superVote.vt)
+            }
         }
         // and burn some coins, update bw/vt and leader vote scores as usual
         cache.updateOne('accounts', {name: tx.sender}, {$inc: {balance: -tx.data.burn}}, function() {
@@ -68,7 +70,7 @@ module.exports = {
                         // insert content+vote into db
                         cache.insertOne('contents', newContent, function(){
                             eco.curation(tx.sender, tx.data.link, function(distCurators, distMaster) {
-                                if (tx.data.pa && tx.data.pp) 
+                                if (tx.data.pa && tx.data.pp && process.env.CONTENT == '1')
                                     cache.updateOne('contents', {_id: tx.data.pa+'/'+tx.data.pp}, { $push: {
                                         child: [tx.sender, tx.data.link]
                                     }}, function() {
@@ -77,7 +79,7 @@ module.exports = {
                                 else {
                                     // and report how much was burnt
                                     cb(true, distCurators+distMaster, tx.data.burn)
-                                    rankings.new(newContent)
+                                    if (!tx.data.pa || !tx.data.pp) rankings.new(newContent)
                                 }
                             }) 
                             

--- a/src/transactions/promotedComment.js
+++ b/src/transactions/promotedComment.js
@@ -54,12 +54,10 @@ module.exports = {
             votes: [superVote],
             ts: ts
         }
-        if (tx.data.tag)  {
+        if (tx.data.tag && process.env.CONTENTS == '1')  {
             superVote.tag = tx.data.tag
-            if (process.env.CONTENTS == '1') {
-                newContent.tags = {}
-                newContent.tags[tx.data.tag] = Math.abs(superVote.vt)
-            }
+            newContent.tags = {}
+            newContent.tags[tx.data.tag] = Math.abs(superVote.vt)
         }
         // and burn some coins, update bw/vt and leader vote scores as usual
         cache.updateOne('accounts', {name: tx.sender}, {$inc: {balance: -tx.data.burn}}, function() {

--- a/src/transactions/vote.js
+++ b/src/transactions/vote.js
@@ -42,7 +42,14 @@ module.exports = {
         cache.updateOne('contents', {_id: tx.data.author+'/'+tx.data.link},{$push: {
             votes: vote
         }}, function(){
-            if (process.env.CONTENT == '1') cache.findOne('contents', {_id: tx.data.author+'/'+tx.data.link}, function(err, content) {
+            cache.findOne('contents', {_id: tx.data.author+'/'+tx.data.link}, function(err, content) {
+                if (process.env.CONTENT != '1') {
+                    return eco.curation(tx.data.author, tx.data.link, function(distCurators, distMaster, burnCurator) {
+                        if (!content.pa && !content.pp)
+                            rankings.update(tx.data.author, tx.data.link, vote, distCurators)
+                        cb(true, distCurators+distMaster, burnCurator)
+                    })
+                }
                 // update top tags
                 var topTags = []
                 for (let i = 0; i < content.votes.length; i++) {
@@ -73,11 +80,6 @@ module.exports = {
                         cb(true, distCurators+distMaster, burnCurator)
                     })
                 })
-            })
-            else eco.curation(tx.data.author, tx.data.link, function(distCurators, distMaster, burnCurator) {
-                if (!content.pa && !content.pp)
-                    rankings.update(tx.data.author, tx.data.link, vote, distCurators)
-                cb(true, distCurators+distMaster, burnCurator)
             })
         })
     }

--- a/src/transactions/vote.js
+++ b/src/transactions/vote.js
@@ -43,7 +43,7 @@ module.exports = {
             votes: vote
         }}, function(){
             cache.findOne('contents', {_id: tx.data.author+'/'+tx.data.link}, function(err, content) {
-                if (process.env.CONTENT != '1') {
+                if (process.env.CONTENTS != '1') {
                     return eco.curation(tx.data.author, tx.data.link, function(distCurators, distMaster, burnCurator) {
                         if (!content.pa && !content.pp)
                             rankings.update(tx.data.author, tx.data.link, vote, distCurators)

--- a/src/transactions/vote.js
+++ b/src/transactions/vote.js
@@ -42,7 +42,7 @@ module.exports = {
         cache.updateOne('contents', {_id: tx.data.author+'/'+tx.data.link},{$push: {
             votes: vote
         }}, function(){
-            cache.findOne('contents', {_id: tx.data.author+'/'+tx.data.link}, function(err, content) {
+            if (process.env.CONTENT == '1') cache.findOne('contents', {_id: tx.data.author+'/'+tx.data.link}, function(err, content) {
                 // update top tags
                 var topTags = []
                 for (let i = 0; i < content.votes.length; i++) {
@@ -73,6 +73,11 @@ module.exports = {
                         cb(true, distCurators+distMaster, burnCurator)
                     })
                 })
+            })
+            else eco.curation(tx.data.author, tx.data.link, function(distCurators, distMaster, burnCurator) {
+                if (!content.pa && !content.pp)
+                    rankings.update(tx.data.author, tx.data.link, vote, distCurators)
+                cb(true, distCurators+distMaster, burnCurator)
             })
         })
     }

--- a/src/transactions/vote.js
+++ b/src/transactions/vote.js
@@ -69,7 +69,7 @@ module.exports = {
                 topTags = topTags.slice(0, config.tagMaxPerContent)
                 var tags = {}
                 for (let i = 0; i < topTags.length; i++)
-                    tags[topTags[i].tag] = topTags[i].vt
+                    tags[topTags[i].tag.replace(/\$/g,'').replace(/\./g,'')] = topTags[i].vt
                 cache.updateOne('contents', {_id: tx.data.author+'/'+tx.data.link},{$set: {
                     tags: tags
                 }}, function(){

--- a/src/transactions/vote.js
+++ b/src/transactions/vote.js
@@ -66,10 +66,18 @@ module.exports = {
                 topTags = topTags.sort(function(a,b) {
                     return b.vt - a.vt
                 })
-                topTags = topTags.slice(0, config.tagMaxPerContent)
-                var tags = {}
-                for (let i = 0; i < topTags.length; i++)
-                    tags[topTags[i].tag.replace(/\$/g,'').replace(/\./g,'')] = topTags[i].vt
+                let tags = {}
+                let tagKeys = 0
+                let tagLoop = 0
+                while (tagKeys < config.tagMaxPerContent && tagLoop < topTags.length) {
+                    let t = topTags[tagLoop].tag.replace(/\$/g,'').replace(/\./g,'')
+                    // tag must not be empty after filtering
+                    if (t) {
+                        tags[t] = topTags[tagLoop].vt
+                        tagKeys++
+                    }
+                    tagLoop++
+                }
                 cache.updateOne('contents', {_id: tx.data.author+'/'+tx.data.link},{$set: {
                     tags: tags
                 }}, function(){


### PR DESCRIPTION
A few changes have been made with regards to the behaviour of rebuilds for performance improvements.

* Notifications only begins processing when rebuilding the last 201,600 blocks
* Rebuild performance (in blocks/second) is now logged in the console
* Blocks are now loaded in batches of 10,000 blocks instead of one-by-one
* Mongo writes are now executed in parallel for every block
* Added `CONTENTS` module for content JSON, tags and comment details that are not needed for consensus. Results in ~15% savings in disk utilization in `contents` collection, or 5% across the database.

These changes resulted in a 26% faster rebuild with `CONTENTS=1`, and an additional ~1% with `CONTENTS=0`.