### PR TITLE
Author tip hardfork

### DIFF
--- a/scripts/tipvote_updater.js
+++ b/scripts/tipvote_updater.js
@@ -1,0 +1,23 @@
+// RUN THIS WHEN UPDATING FOR AUTHOR TIP HARDFORK
+const MongoClient = require('mongodb').MongoClient
+const url = 'mongodb://localhost:27017'
+const dbName = 'avalon'
+let updateCount = 0
+MongoClient.connect(url, {useUnifiedTopology: true}, function(err, client) {
+    let db = client.db(dbName)
+    db.collection('contents').find({}).toArray(async (e,contents) => {
+        for (let c in contents) {
+            let updateVotes = contents[c].votes
+            for (let v in updateVotes)
+                updateVotes[v].gross = updateVotes[v].claimable
+            db.collection('contents').updateOne({_id: contents[c]._id},{$set:{votes:updateVotes}}).then(() => {
+                updateCount++
+                if (updateCount === contents.length) {
+                    console.log('update complete')
+                    process.exit(0)
+                }
+            })
+        }
+        console.log('updating',contents.length,'docs')
+    })
+})

--- a/src/cli.js
+++ b/src/cli.js
@@ -269,6 +269,23 @@ program.command('sign <transaction>')
         writeLine('  $ sign \'{"type":1,"data":{"target":"bob"}}\' -F key.json -M alice')
     })
 
+program.command('tipped-vote <link> <author> <vt> <tag> <tip>')
+    .description('vote for a content with a % of curation rewards tipped to author')
+    .action(function(link, author, vt, tag, tip) {
+        verifyAndSendTx('tippedVote', link, author, vt, tag, tip)
+    }).on('--help', function(){
+        writeLine('')
+        writeLine('Arguments:')
+        writeLine('  <link>: the identifier of the comment to vote on')        
+        writeLine('  <author>: the author of the comment to vote on')
+        writeLine('  <vt>: the amount of VT to spend on the vote')
+        writeLine('  <tag>: the tag to associate with the vote')
+        writeLine('  <tip>: the tip weight (1 => 1%, 100 => 100% of rewards claimable by author)')
+        writeLine('')
+        writeLine('Examples:')
+        writeLine('  $ tipped-vote awesome-video alice 1000 introduce-yourself 15 -F key.json -M bob')
+    })
+
 program.command('transfer <receiver> <amount>')
     .alias('xfer')
     .option('--memo [text]', 'add a short message to the transfer')    

--- a/src/clicmds.js
+++ b/src/clicmds.js
@@ -153,6 +153,15 @@ let cmds = {
 			pub+'"}}'
         return sign(privKey, sender, tx)
     },
+
+    tippedVote: (privkey, sender, link, author, weight, tag, tip) => {
+        if (!tag) tag = ''
+        let tx = '{"type":19,"data":{"link":"'+
+            link+'", "author":"'+
+            author+'", "vt": '+
+            parseInt(weight)+', "tag": "'+tag+'", "tip": ' + parseInt(tip) + '}}'
+        return sign(privkey, sender, tx)
+    }
 }
 
 module.exports = cmds

--- a/src/config.js
+++ b/src/config.js
@@ -112,6 +112,7 @@ var config = {
             txLimits: {
                 14: 2,
                 15: 2,
+                19: 1
             },
             // the number of ms needed for 0.01 DTC to generate 1 vt
             vtGrowth: 360000000, // +1 vt per hour per DTC (3600 * 1000 * 100)
@@ -121,6 +122,18 @@ var config = {
             leaders: 13,
             leaderRewardVT: 100,
             vtPerBurn: 44
+        },
+        6000000: {
+            // maximum scale of author tip percentage
+            // 100 => 1% step
+            // 1000 => 0.1% step
+            // 10000 => 0.01% step
+            tippedVotePrecision: 2,
+            txLimits: {
+                14: 2,
+                15: 2,
+                19: 0
+            }
         }
     },
     read: (blockNum) => {

--- a/src/config.js
+++ b/src/config.js
@@ -103,6 +103,9 @@ var config = {
             // the maximum length of tags (on votes)
             tagMaxLength: 25,
             tagMaxPerContent: 5,
+            // precision of author tip percentage
+            // 1 => 10% step, 2 => 1% step, 3 => 0.1% step, 4 => 0.01% step
+            tippedVotePrecision: 2,
             tmpForceTs: true,
             // the time after which transactions expire and wont be accepted by nodes anymore
             txExpirationTime: 60000,
@@ -124,11 +127,6 @@ var config = {
             vtPerBurn: 44
         },
         6000000: {
-            // maximum scale of author tip percentage
-            // 100 => 1% step
-            // 1000 => 0.1% step
-            // 10000 => 0.01% step
-            tippedVotePrecision: 2,
             txLimits: {
                 14: 2,
                 15: 2,

--- a/src/economics.js
+++ b/src/economics.js
@@ -190,6 +190,7 @@ var eco = {
                     if (newVotes[v].u === content.author) {
                         authorVote = v
                         if (newVotes[v].claimed) authorVoteClaimed = true
+                        if (!config.allowRevotes) break
                     }
                 for (let v = 0; v < newVotes.length; v++)
                     if (authorVote >= 0 && newVotes[v].u !== content.author && newVotes[v].tip) {

--- a/src/economics.js
+++ b/src/economics.js
@@ -132,14 +132,14 @@ var eco = {
                 // share the new coins between winners
                 var newCoins = 0
                 for (let i = 0; i < winners.length; i++) {
-                    if (!winners[i].claimable)
-                        winners[i].claimable = 0
+                    if (!winners[i].gross)
+                        winners[i].gross = 0
                     
                     var won = thNewCoins * winners[i].share
                     var rentabilityWinner = eco.rentability(winners[i].ts, currentVote.ts)
                     won *= rentabilityWinner
                     won = Math.floor(won*Math.pow(10, config.ecoClaimPrecision))/Math.pow(10, config.ecoClaimPrecision)
-                    winners[i].claimable += won
+                    winners[i].gross += won
                     newCoins += won
                     delete winners[i].share
 
@@ -165,14 +165,14 @@ var eco = {
                     if (i === 0 && !config.ecoPunishAuthor)
                         break
                     if (!content.votes[i].claimed && content.votes[i].vt*currentVote.vt < 0)
-                        if (content.votes[i].claimable >= takeAwayAmount) {
-                            content.votes[i].claimable -= takeAwayAmount
+                        if (content.votes[i].gross >= takeAwayAmount) {
+                            content.votes[i].gross -= takeAwayAmount
                             newBurn += takeAwayAmount
                             takeAwayAmount = 0
                         } else {
-                            takeAwayAmount -= content.votes[i].claimable
-                            newBurn += content.votes[i].claimable
-                            content.votes[i].claimable = 0
+                            takeAwayAmount -= content.votes[i].gross
+                            newBurn += content.votes[i].gross
+                            content.votes[i].gross = 0
                         }
                     i--
                 }
@@ -180,6 +180,30 @@ var eco = {
                 
                 logr.econ(newCoins + ' dist from the vote')
                 logr.econ(newBurn + ' burn from the vote')
+
+                // compute final claimable amount after author tip
+                let authorVote = -1
+                let authorVoteClaimed = false
+                let totalAuthorTip = 0
+                let precisionMulti = Math.pow(10,config.ecoClaimPrecision+config.tippedVotePrecision)
+                for (let v = 0; v < newVotes.length; v++)
+                    if (newVotes[v].u === content.author) {
+                        authorVote = v
+                        if (newVotes[v].claimed) authorVoteClaimed = true
+                    }
+                for (let v = 0; v < newVotes.length; v++)
+                    if (authorVote >= 0 && newVotes[v].u !== content.author && newVotes[v].tip) {
+                        if (!authorVoteClaimed) {
+                            let tipAmt = (newVotes[v].gross * Math.pow(10,config.ecoClaimPrecision)) * (newVotes[v].tip * Math.pow(10,config.tippedVotePrecision))
+                            totalAuthorTip += tipAmt
+                            newVotes[v].totalTip = tipAmt / precisionMulti
+                            newVotes[v].claimable = ((newVotes[v].gross * precisionMulti) - tipAmt) / precisionMulti
+                        } else
+                            newVotes[v].claimable = (newVotes[v].gross * precisionMulti) - (newVotes[v].totalTip * precisionMulti) / precisionMulti
+                    } else
+                        newVotes[v].claimable = newVotes[v].gross
+                if (authorVote >= 0)
+                    newVotes[authorVote].claimable = ((newVotes[authorVote].gross * precisionMulti) + totalAuthorTip) / precisionMulti
 
                 // add dist/burn/votes to currentBlock eco stats
                 eco.currentBlock.dist += newCoins

--- a/src/economics.js
+++ b/src/economics.js
@@ -199,10 +199,10 @@ var eco = {
                             newVotes[v].totalTip = tipAmt / precisionMulti
                             newVotes[v].claimable = ((newVotes[v].gross * precisionMulti) - tipAmt) / precisionMulti
                         } else
-                            newVotes[v].claimable = (newVotes[v].gross * precisionMulti) - (newVotes[v].totalTip * precisionMulti) / precisionMulti
-                    } else
+                            newVotes[v].claimable = ((newVotes[v].gross * precisionMulti) - (newVotes[v].totalTip * precisionMulti)) / precisionMulti
+                    } else if (newVotes[v].u !== content.author)
                         newVotes[v].claimable = newVotes[v].gross
-                if (authorVote >= 0)
+                if (authorVote >= 0 && !authorVoteClaimed)
                     newVotes[authorVote].claimable = ((newVotes[authorVote].gross * precisionMulti) + totalAuthorTip) / precisionMulti
 
                 // add dist/burn/votes to currentBlock eco stats

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -48,7 +48,7 @@ notifications = {
             // comment: see https://github.com/busyorg/busy-api/blob/develop/server.js#L125
                 
             /** Find replies */
-            if (tx.data.pa) {
+            if (tx.data.pa && tx.data.pa !== tx.sender) {
                 notif = {
                     u: tx.data.pa,
                     tx: tx,

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -88,6 +88,7 @@ notifications = {
             break
 
         case TransactionType.VOTE:
+        case TransactionType.TIPPED_VOTE:
             notif = {
                 u: tx.data.author,
                 tx: tx,

--- a/src/p2p.js
+++ b/src/p2p.js
@@ -1,4 +1,4 @@
-const version = '1.2'
+const version = '1.3'
 const default_port = 6001
 const replay_interval = 1500
 const discovery_interval = 60000

--- a/src/transactions/comment.js
+++ b/src/transactions/comment.js
@@ -19,7 +19,7 @@ module.exports = {
         }
         // users need to vote the content at the same time with vt and tag field
         if (!validate.integer(tx.data.vt, false, true)) {
-            cb(false, 'invalid tx data.vt'); return
+            cb(false, 'invalid tx data.vt must be a non-zero integer'); return
         }
         if (!validate.string(tx.data.tag, config.tagMaxLength)) {
             cb(false, 'invalid tx data.tag'); return

--- a/src/transactions/index.js
+++ b/src/transactions/index.js
@@ -21,7 +21,8 @@ var transactions = [
     require('./transferBw.js'),
     require('./limitVt.js'),
     require('./claimReward.js'),
-    require('./enableNode.js')
+    require('./enableNode.js'),
+    require('./tippedVote.js')
 ]
 
 module.exports = {
@@ -44,7 +45,8 @@ module.exports = {
         TRANSFER_BW: 15,
         LIMIT_VT: 16,
         CLAIM_REWARD: 17,
-        ENABLE_NODE: 18
+        ENABLE_NODE: 18,
+        TIPPED_VOTE: 19
     },
     validate: (tx, ts, legitUser, cb) => {
         // logr.debug('tx:'+tx.type+' validation begins')

--- a/src/transactions/tippedVote.js
+++ b/src/transactions/tippedVote.js
@@ -34,6 +34,7 @@ module.exports = {
                     authorVote = true
                     if (content.votes[v].claimed)
                         authorVoteClaimed = true
+                    break
                 }
             }
 

--- a/src/transactions/tippedVote.js
+++ b/src/transactions/tippedVote.js
@@ -9,7 +9,7 @@ module.exports = {
             return cb(false, 'invalid tx data.link')
         
         if (!validate.integer(tx.data.vt, false, true))
-            return cb(false, 'invalid tx data.vt')
+            return cb(false, 'invalid tx data.vt must be a non-zero integer')
         
         if (!validate.string(tx.data.tag, config.tagMaxLength))
             return cb(false, 'invalid tx data.tag')

--- a/src/transactions/tippedVote.js
+++ b/src/transactions/tippedVote.js
@@ -1,27 +1,49 @@
 module.exports = {
-    fields: ['link', 'author', 'vt', 'tag'],
+    fields: ['link', 'author', 'vt', 'tag', 'tip'],
     validate: (tx, ts, legitUser, cb) => {
-        if (!validate.string(tx.data.author, config.accountMaxLength, config.accountMinLength, config.allowedUsernameChars, config.allowedUsernameCharsOnlyMiddle)) {
-            logr.debug('invalid tx data.author')
-            cb(false); return
-        }
-        if (!validate.string(tx.data.link, config.accountMaxLength, config.accountMinLength)) {
-            cb(false, 'invalid tx data.link'); return
-        }
-        if (!validate.integer(tx.data.vt, false, true)) {
-            cb(false, 'invalid tx data.vt'); return
-        }
-        if (!validate.string(tx.data.tag, config.tagMaxLength)) {
-            cb(false, 'invalid tx data.tag'); return
-        }
-        if (!transaction.hasEnoughVT(tx.data.vt, ts, legitUser)) {
-            cb(false, 'invalid tx not enough vt'); return
-        }
-        // checking if content exists
-        cache.findOne('contents', {_id: tx.data.author+'/'+tx.data.link}, function(err, content) {
-            if (!content) {
-                cb(false, 'invalid tx non-existing content'); return
+        // Check if author vote exists and whether author has claimed the reward
+        if (!validate.string(tx.data.author, config.accountMaxLength, config.accountMinLength, config.allowedUsernameChars, config.allowedUsernameCharsOnlyMiddle))
+            return cb(false, 'invalid tx data.author')
+        
+        if (!validate.string(tx.data.link, config.accountMaxLength, config.accountMinLength))
+            return cb(false, 'invalid tx data.link')
+        
+        if (!validate.integer(tx.data.vt, false, true))
+            return cb(false, 'invalid tx data.vt')
+        
+        if (!validate.string(tx.data.tag, config.tagMaxLength))
+            return cb(false, 'invalid tx data.tag')
+        
+        if (!transaction.hasEnoughVT(tx.data.vt, ts, legitUser))
+            return cb(false, 'invalid tx not enough vt')
+
+        // tip should be between 1 and 10^config.tippedVotePrecision
+        if (!validate.integer(tx.data.tip,false,false,Math.pow(10,config.tippedVotePrecision),1))
+            return cb(false, 'invalid author tip value')
+        
+        cache.findOne('contents', {_id: tx.data.author+'/'+tx.data.link}, (err, content) => {
+            if (err) throw err
+            if (!content) return cb(false, 'cannot vote and tip non-existent content')
+            if (content.votes.length === 0) return cb(false, 'no votes in this content to tip author with')
+
+            // author should be voted and not claimed reward
+            let authorVote = false
+            let authorVoteClaimed = false
+            for (let v = 0; v < content.votes.length; v++) {
+                if (content.votes[v].u === tx.data.author) {
+                    authorVote = true
+                    if (content.votes[v].claimed)
+                        authorVoteClaimed = true
+                }
             }
+
+            // probably content imported from genesis
+            if (!authorVote) return cb(false, 'author vote does not exist')
+
+            // can only tip author that have not claimed reward
+            if (authorVoteClaimed) return cb(false, 'author has already claimed reward')
+
+            // the remaining validations are the same as votes without author tip
             if (!config.allowRevotes) 
                 for (let i = 0; i < content.votes.length; i++) 
                     if (tx.sender === content.votes[i].u) {
@@ -31,10 +53,12 @@ module.exports = {
         })
     },
     execute: (tx, ts, cb) => {
+        // same as vote but with (tx.data.tip / 10^config.tippedVotePrecision) of rewards tipped to author (first vote)
         var vote = {
             u: tx.sender,
             ts: ts,
-            vt: tx.data.vt
+            vt: tx.data.vt,
+            tip: tx.data.tip/Math.pow(10,config.tippedVotePrecision)
         }
         if (tx.data.tag) vote.tag = tx.data.tag
         cache.updateOne('contents', {_id: tx.data.author+'/'+tx.data.link},{$push: {

--- a/src/transactions/vote.js
+++ b/src/transactions/vote.js
@@ -9,7 +9,7 @@ module.exports = {
             cb(false, 'invalid tx data.link'); return
         }
         if (!validate.integer(tx.data.vt, false, true)) {
-            cb(false, 'invalid tx data.vt'); return
+            cb(false, 'invalid tx data.vt must be a non-zero integer'); return
         }
         if (!validate.string(tx.data.tag, config.tagMaxLength)) {
             cb(false, 'invalid tx data.tag'); return


### PR DESCRIPTION
As discussed in #53, this hardfork adds a new transaction type 19 which allows curators to tip a percentage of the curation rewards directly to the author, such that it is claimable by the author of the content instead of the voter.

The new transaction is the same as `VOTE` transaction (type 5) with an addition of an integer called `tip`, which defines the % value to be tipped to the author. It may be from 1 to 100, where 1 represents a 1% tip, up to 100%.

There are two requirements that must be met to cast a tipped vote for mostly technical reasons:
1. Author vote must be present (most contents imported from genesis do not have author votes)
2. Author vote must not be claimed

Please express your approval or disapproval for this hardfork by a thumbs up (or down) so that we can merge this as soon as possible. The hardfork will be set to activate in about 144,000 blocks (~5 days) from the time it gets approved and merged. Update instructions to follow.

For those who want to see it in action before the hardfork activation, a testnet is currently running on https://testnet-api.oneloved.tube (block explorer: https://testnet-blocks.oneloved.tube) using state from mainnet block 4,350,027.