### PR TITLE
Sorting by timestamp for /blog endpoint

### DIFF
--- a/src/http/blog/index.js
+++ b/src/http/blog/index.js
@@ -3,7 +3,47 @@ module.exports = {
         // get blog of user
         app.get('/blog/:username', (req, res) => {
             var username = req.params.username
+
             db.collection('contents').find({ pa: null, author: username }, { sort: { ts: -1 }, limit: 50 }).toArray(function (err, contents) {
+                res.send(contents)
+            })
+        })
+        app.get('/blog/:username/:filter', (req, res) => {
+            var username = req.params.username
+            var filterParam = req.params.filter
+            var filter = filterParam.split(':')
+            var filterBy = filter[1]
+            var filterAttrs = filterBy.split('&')
+
+            var filterMap = {}
+            var defaultKeys = ['sortBy']
+            var filterKeys = []
+
+            var limit = 50
+            for (var k=0; k<filterAttrs.length; k++) {
+                var kv = filterAttrs[k].split('=')
+
+                if (kv.length == 2) {
+                    var key = kv[0]
+                    filterKeys.push(key)
+                    var val = kv[1]
+
+                    if (key == 'sortBy') {
+                        filterMap['sortBy'] = val
+                    } else if (key == 'limit') {
+                        filterMap['limit'] = parseInt(val)
+                        limit = filterMap['limit']
+                    }
+                }
+            }
+            var ts = -1
+            if (filterMap['sortBy'] == 'desc') {
+                ts = -1
+            } else if (filterMap['sortBy'] == 'asc') {
+                ts = 1
+            }
+
+            db.collection('contents').find({ pa: null, author: username }, { sort: { ts: ts }, limit: limit }).toArray(function (err, contents) {
                 res.send(contents)
             })
         })

--- a/src/http/content/index.js
+++ b/src/http/content/index.js
@@ -52,5 +52,180 @@ module.exports = {
                 })
             })
         })
+
+        // get content by tag with limit by certain author
+        // filter = author,tag,limit,ts(from, to)
+        // $API_URL/filter?author=author1,author2,...,authorN&tag=tag1,tag2,...,tagN&limit=x&ts=tsfrom-tsto
+        app.get('/content/:filter', (req, res) => {
+            var filterParam = req.params.filter
+            var filter = filterParam.split(':')
+            var filterBy = filter[1]
+            var filterAttrs = filterBy.split('&')
+
+            var filterMap = {}
+            var defaultKeys = ['authors', 'tags', 'limit', 'tsrange']
+            var filterKeys = []
+
+            for (var k=0; k<filterAttrs.length; k++) {
+                var kv = filterAttrs[k].split('=')
+
+                if (kv.length == 2) {
+                    var key = kv[0]
+                    filterKeys.push(key)
+                    var val = kv[1]
+
+                    if (key == 'authors') {
+                        filterMap['authors'] = val.split(',')
+                    } else if (key == 'tags') {
+                        filterMap['tags'] = val.split(',')
+                    } else if (key == 'limit') {
+                        filterMap['limit'] = parseInt(val)
+                    } else if (key == 'tsrange') {
+                        filterMap['tsrange'] = val.split(',')
+                    }
+                }
+            }
+
+            for (var k=0; k<defaultKeys.length; k++) {
+                var key = defaultKeys[k]
+
+                if (filterKeys.includes(key) == false) {
+                    if (key == 'authors') {
+                        filterMap['authors'] = []
+                        filterMap['authors'].push("all")
+                    } else if (key == 'tags') {
+                        filterMap['tags'] = []
+                        filterMap['tags'].push("all")
+                    } else if (key == 'limit') {
+                        filterMap['limit'] = Number.MAX_SAFE_INTEGER
+                    } else if (key == 'tsrange') {
+                        filterMap['tsrange'] = []
+                        filterMap['tsrange'].push(0)
+                        filterMap['tsrange'].push(Number.MAX_SAFE_INTEGER)
+                    }
+                }
+            }
+
+            authors = filterMap['authors']
+
+            authors_in = []
+            authors_ex = []
+            for(var i=0; i<authors.length; i++) {
+                if(authors[i].includes("^")) {
+                    s = authors[i].substring(1, authors[i].length)
+                    authors_ex.push(s)
+                }
+                else {
+                    authors_in.push(authors[i])
+                }
+            }
+
+            tags = filterMap['tags']
+
+            tags_in = []
+            tags_ex = []
+            for(var i=0; i<tags.length; i++) {
+                if(tags[i].includes("^")) {
+                    s = tags[i].substring(1, tags[i].length)
+                    tags_ex.push(s)
+                } else {
+                    tags_in.push(tags[i])
+                }
+            }
+
+            limit = filterMap['limit']
+
+            if(limit == -1) {
+                limit = Number.MAX_SAFE_INTEGER
+            }
+
+            tsrange = filterMap['tsrange']
+            if (tsrange.length == 2) {
+                tsfrom = parseInt(tsrange[0]) * 1000
+                tsto = parseInt(tsrange[1]) * 1000
+            } else {
+                return
+            }
+
+            if (authors.includes("all") && !tags.includes("all")) {
+                db.collection('contents').find({
+                    $and: [
+                        { author: { $nin : authors_ex } },
+                        {
+                            $or: [
+                                {
+                                    $and: [
+                                        { 'json.tag': { $in: tags_in } },
+                                        { 'json.tag': { $nin: tags_ex } },
+                                    ],
+                                },
+                                {
+                                    $and: [
+                                        { votes: { $elemMatch: { tag: { $in: tags_in } } } },
+                                        { votes: { $elemMatch: { tag: { $nin: tags_ex } } } }
+                                    ]
+                                }
+                            ]
+                        },
+                        { ts: { $gte: tsfrom } },
+                        { ts: { $lte: tsto } }
+                    ]
+                }, { sort: {ts:-1}, limit: limit}).toArray(function (err, contents) {
+                    res.send(contents)
+                })
+            } else if (!authors.includes("all") && !tags.includes("all")) {
+                db.collection('contents').find({
+                    $and: [
+                        { author: { $in : authors_in } },
+                        { author: { $nin : authors_ex } },
+                        {
+                            $or: [
+                                {
+                                    $and: [
+                                        { 'json.tag': { $in: tags_in } },
+                                        { 'json.tag': { $nin: tags_ex } },
+                                    ],
+                                },
+                                {
+                                    $and: [
+                                        { votes: { $elemMatch: { tag: { $in: tags_in } } } },
+                                        { votes: { $elemMatch: { tag: { $nin: tags_ex } } } }
+                                    ]
+                                }
+                            ]
+                        },
+                        { ts: { $gte: tsfrom } },
+                        { ts: { $lte: tsto } }
+                    ]
+                }, { sort: {ts:-1}, limit: limit }).toArray(function (err, contents) {
+                    res.send(contents)
+                })
+            } else if (authors.includes("all") && tags.includes("all")) {
+                db.collection('contents').find({
+                    $and: [
+                        { author: { $nin : authors_ex } },
+                        { 'json.tag': { $nin: tags_ex } },
+                        { votes: { $elemMatch: { tag: { $nin: tags_ex } } } },
+                        { ts: { $gte: tsfrom } },
+                        { ts: { $lte: tsto } }
+                    ]
+                }, { sort: {ts:-1}, limit: limit }).toArray(function (err, contents) {
+                    res.send(contents)
+                })
+            } else if (!authors.includes("all")  && tags.includes("all")) {
+                db.collection('contents').find({
+                    $and: [
+                        { author: { $in : authors_in } },
+                        { author: { $nin : authors_ex } },
+                        { 'json.tag': { $nin: tags_ex } },
+                        { votes: { $elemMatch: { tag: { $nin: tags_ex } } } },
+                        { ts: { $gte: tsfrom } },
+                        { ts: { $lte: tsto } }
+                    ]
+                }, { sort: {ts:-1}, limit: limit }).toArray(function (err, contents) {
+                    res.send(contents)
+                })
+            }
+        })
     }
 }

--- a/src/http/feed/index.js
+++ b/src/http/feed/index.js
@@ -25,7 +25,7 @@ module.exports = {
                 ]
             }, function (err, content) {
                 db.collection('accounts').findOne({ name: req.params.username }, function (err, account) {
-                    if (!account || !account.follows)
+                    if (!account.follows)
                         res.send([])
                     else
                         db.collection('contents').find({
@@ -40,6 +40,213 @@ module.exports = {
 
                 })
             })
+        })
+
+        // get feed by tag with limit by certain author
+        // filter = author,tag,limit,ts(from, to)
+        // $API_URL/filter?author=author1,author2,...,authorN&tag=tag1,tag2,...,tagN&limit=x&ts=tsfrom-tsto
+        app.get('/feed/:username/:filter', (req, res) => {
+            var filterParam = req.params.filter
+            var filter = filterParam.split(':')
+            var filterBy = filter[1]
+            var filterAttrs = filterBy.split('&')
+
+            var filterMap = {}
+            var defaultKeys = ['authors', 'tags', 'limit', 'tsrange']
+            var filterKeys = []
+
+            for (var k=0; k<filterAttrs.length; k++) {
+                var kv = filterAttrs[k].split('=')
+
+                if (kv.length == 2) {
+                    var key = kv[0]
+                    filterKeys.push(key)
+                    var val = kv[1]
+
+                    if (key == 'authors') {
+                        filterMap['authors'] = val.split(',')
+                    } else if (key == 'tags') {
+                        filterMap['tags'] = val.split(',')
+                    } else if (key == 'limit') {
+                        filterMap['limit'] = parseInt(val)
+                    } else if (key == 'tsrange') {
+                        filterMap['tsrange'] = val.split(',')
+                    }
+                }
+            }
+
+            for (var k=0; k<defaultKeys.length; k++) {
+                var key = defaultKeys[k]
+
+                if (filterKeys.includes(key) == false) {
+                    if (key == 'authors') {
+                        filterMap['authors'] = []
+                        filterMap['authors'].push("all")
+                    } else if (key == 'tags') {
+                        filterMap['tags'] = []
+                        filterMap['tags'].push("all")
+                    } else if (key == 'limit') {
+                        filterMap['limit'] = 50
+                    } else if (key == 'tsrange') {
+                        filterMap['tsrange'] = []
+                        filterMap['tsrange'].push(0)
+                        filterMap['tsrange'].push(Number.MAX_SAFE_INTEGER)
+                    }
+                }
+            }
+
+            authors = filterMap['authors']
+
+            authors_in = []
+            authors_ex = []
+            for(var i=0; i<authors.length; i++) {
+                if(authors[i].includes("^")) {
+                    s = authors[i].substring(1, authors[i].length)
+                    authors_ex.push(s)
+                }
+                else {
+                    authors_in.push(authors[i])
+                }
+            }
+
+            tags = filterMap['tags']
+
+            tags_in = []
+            tags_ex = []
+            for(var i=0; i<tags.length; i++) {
+                if(tags[i].includes("^")) {
+                    s = tags[i].substring(1, tags[i].length)
+                    tags_ex.push(s)
+                } else {
+                    tags_in.push(tags[i])
+                }
+            }
+
+            limit = filterMap['limit']
+
+            if(limit == -1) {
+                limit = Number.MAX_SAFE_INTEGER
+            }
+
+            tsrange = filterMap['tsrange']
+            if (tsrange.length == 2) {
+                tsfrom = parseInt(tsrange[0]) * 1000
+                tsto = parseInt(tsrange[1]) * 1000
+            } else {
+                return
+            }
+
+            if (authors.includes("all") && !tags.includes("all")) {
+                db.collection('accounts').findOne({ name: req.params.username }, function (err, account) {
+                    if (!account.follows)
+                        res.send([])
+                    else {
+                        db.collection('contents').find({
+                            $and: [
+                                { author: { $in: account.follows } },
+                                { author: { $nin : authors_ex } },
+                                { pa: null },
+                                {
+                                    $or: [
+                                        {
+                                            $and: [
+                                                { 'json.tag': { $in: tags_in } },
+                                                { 'json.tag': { $nin: tags_ex } },
+                                            ],
+                                        },
+                                        {
+                                            $and: [
+                                                { votes: { $elemMatch: { tag: { $in: tags_in } } } },
+                                                { votes: { $elemMatch: { tag: { $nin: tags_ex } } } }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                { ts: { $gte: tsfrom } },
+                                { ts: { $lte: tsto } },
+                            ]
+                        }, { sort: {ts:-1}, limit: limit}).toArray(function (err, contents) {
+                            res.send(contents)
+                        })
+                    }
+                })
+            } else if (!authors.includes("all") && !tags.includes("all")) {
+                db.collection('accounts').findOne({ name: req.params.username }, function (err, account) {
+                    if (!account.follows)
+                        res.send([])
+                    else {
+                        db.collection('contents').find({
+                            $and: [
+                                { author: { $in: account.follows } },
+                                { author: { $in : authors_in } },
+                                { author: { $nin : authors_ex } },
+                                { pa: null },
+                                {
+                                    $or: [
+                                        {
+                                            $and: [
+                                                { 'json.tag': { $in: tags_in } },
+                                                { 'json.tag': { $nin: tags_ex } },
+                                            ],
+                                        },
+                                        {
+                                            $and: [
+                                                { votes: { $elemMatch: { tag: { $in: tags_in } } } },
+                                                { votes: { $elemMatch: { tag: { $nin: tags_ex } } } }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                { ts: { $gte: tsfrom } },
+                                { ts: { $lte: tsto } },
+                            ]
+                        }, { sort: {ts:-1}, limit: limit }).toArray(function (err, contents) {
+                            res.send(contents)
+                        })
+                    }
+                })
+            } else if (authors.includes("all") && tags.includes("all")) {
+                db.collection('accounts').findOne({ name: req.params.username }, function (err, account) {
+                    if (!account.follows)
+                        res.send([])
+                    else {
+                        db.collection('contents').find({
+                            $and: [
+                                { author: { $in: account.follows } },
+                                { author: { $nin : authors_ex } },
+                                { pa: null },
+                                { 'json.tag': { $nin: tags_ex } },
+                                { votes: { $elemMatch: { tag: { $nin: tags_ex } } } },
+                                { ts: { $gte: tsfrom } },
+                                { ts: { $lte: tsto } },
+                            ]
+                        }, { sort: {ts:-1}, limit: limit }).toArray(function (err, contents) {
+                            res.send(contents)
+                        })
+                    }
+                })
+
+            } else if (!authors.includes("all")  && tags.includes("all")) {
+                db.collection('accounts').findOne({ name: req.params.username }, function (err, account) {
+                    if (!account.follows)
+                        res.send([])
+                    else {
+                        db.collection('contents').find({
+                            $and: [
+                                { author: { $in : authors_in } },
+                                { author: { $nin : authors_ex } },
+                                { pa: null },
+                                { 'json.tag': { $nin: tags_ex } },
+                                { votes: { $elemMatch: { tag: { $nin: tags_ex } } } },
+                                { ts: { $gte: tsfrom } },
+                                { ts: { $lte: tsto } },
+                            ]
+                        }, { sort: {ts:-1}, limit: limit }).toArray(function (err, contents) {
+                            res.send(contents)
+                        })
+                    }
+                })
+            }
         })
     }
 }

--- a/src/http/hot/index.js
+++ b/src/http/hot/index.js
@@ -20,5 +20,141 @@ module.exports = {
             }
             res.send(filteredContents)
         })
+        // get hot with tags and limit filter
+        app.get('/hot/:filter', (req, res) => {
+            var filterParam = req.params.filter
+            var filter = filterParam.split(':')
+            var filterBy = filter[1]
+            var filterAttrs = filterBy.split('&')
+
+            var filterMap = {}
+            var defaultKeys = ['tags', 'limit']
+            var filterKeys = []
+
+            for (var k=0; k<filterAttrs.length; k++) {
+                var kv = filterAttrs[k].split('=')
+
+                if (kv.length == 2) {
+                    var key = kv[0]
+                    filterKeys.push(key)
+                    var val = kv[1]
+
+                    if (key == 'tags') {
+                        filterMap['tags'] = val.split(',')
+                    } else if (key == 'limit') {
+                        filterMap['limit'] = parseInt(val)
+                    }
+                }
+            }
+
+            for (var k=0; k<defaultKeys.length; k++) {
+                var key = defaultKeys[k]
+
+                if (filterKeys.includes(key) == false) {
+                    if (key == 'tags') {
+                        filterMap['tags'] = []
+                        filterMap['tags'].push("all")
+                    } else if (key == 'limit') {
+                        filterMap['limit'] = Number.MAX_SAFE_INTEGER
+                    }
+                }
+            }
+
+            tags = filterMap['tags']
+
+            tags_in = []
+            tags_ex = []
+            for(var i=0; i<tags.length; i++) {
+                if(tags[i].includes("^")) {
+                    s = tags[i].substring(1, tags[i].length)
+                    tags_ex.push(s)
+                } else {
+                    tags_in.push(tags[i])
+                }
+            }
+
+            limit = filterMap['limit']
+
+            if(limit == -1) {
+                limit = Number.MAX_SAFE_INTEGER
+            }
+
+            var minTs = new Date().getTime() - rankings.types['hot'].halfLife*rankings.expireFactor
+
+            if (tags.includes('all')) {
+                db.collection('contents').find(
+                    {
+                        $and: [
+                            { pa: null },
+                            { 'json.tag': { $nin: tags_ex } },
+                            { votes: { $elemMatch: { tag: { $nin: tags_ex } } } },
+                            { ts: {'$gt': minTs} }
+                        ]
+                    },
+                    {sort: {ts: -1}}).toArray(function(err, contents) {
+                        for (let i = 0; i < contents.length; i++) {
+                            contents[i].score = 0
+                            contents[i].ups = 0
+                            contents[i].downs = 0
+                            if (!contents[i].dist) contents[i].dist = 0
+                            for (let y = 0; y < contents[i].votes.length; y++) {
+                                if (contents[i].votes[y].vt > 0)
+                                    contents[i].ups += Math.abs(contents[i].votes[y].vt)
+                                if (contents[i].votes[y].vt < 0)
+                                    contents[i].downs += Math.abs(contents[i].votes[y].vt)
+                            }
+                            contents[i].score = rankings.types['hot'].score(contents[i].ups, contents[i].downs, new Date(contents[i].ts))
+                        }
+                        contents = contents.sort(function(a,b) {
+                            return b.score - a.score
+                        })
+                        res.send(contents.slice(0, limit))
+                })
+            } else {
+                db.collection('contents').find(
+                    {
+                        $and: [
+                            { pa: null },
+                            {
+                                $or: [
+                                    {
+                                        $and: [
+                                            { 'json.tag': { $in: tags_in } },
+                                            { 'json.tag': { $nin: tags_ex } },
+                                        ],
+                                    },
+                                    {
+                                        $and: [
+                                            { votes: { $elemMatch: { tag: { $in: tags_in } } } },
+                                            { votes: { $elemMatch: { tag: { $nin: tags_ex } } } }
+                                        ]
+                                    }
+                                ]
+                            },
+                            { ts: {'$gt': minTs} }
+                        ]
+                    },
+                    {sort: {ts: -1}}).toArray(function(err, contents) {
+                        for (let i = 0; i < contents.length; i++) {
+                            contents[i].score = 0
+                            contents[i].ups = 0
+                            contents[i].downs = 0
+                            if (!contents[i].dist) contents[i].dist = 0
+                            for (let y = 0; y < contents[i].votes.length; y++) {
+                                if (contents[i].votes[y].vt > 0)
+                                    contents[i].ups += Math.abs(contents[i].votes[y].vt)
+                                if (contents[i].votes[y].vt < 0)
+                                    contents[i].downs += Math.abs(contents[i].votes[y].vt)
+                            }
+                            contents[i].score = rankings.types['hot'].score(contents[i].ups, contents[i].downs, new Date(contents[i].ts))
+                        }
+                        contents = contents.sort(function(a,b) {
+                            return b.score - a.score
+                        })
+                        //rankings.contents['hot'] = contents
+                        res.send(contents.slice(0, limit))
+                })
+            }
+        })
     }
 }

--- a/src/http/new/index.js
+++ b/src/http/new/index.js
@@ -27,5 +27,182 @@ module.exports = {
                 })
             })
         })
+
+        // get new contents with filter by author, tag, limit, tsrange
+        app.get('/new/:filter', (req, res) => {
+            var filterParam = req.params.filter
+            var filter = filterParam.split(':')
+            var filterBy = filter[1]
+            var filterAttrs = filterBy.split('&')
+
+            var filterMap = {}
+            var defaultKeys = ['authors', 'tags', 'limit', 'tsrange']
+            var filterKeys = []
+
+            for (var k=0; k<filterAttrs.length; k++) {
+                var kv = filterAttrs[k].split('=')
+
+                if (kv.length == 2) {
+                    var key = kv[0]
+                    filterKeys.push(key)
+                    var val = kv[1]
+
+                    if (key == 'authors') {
+                        filterMap['authors'] = val.split(',')
+                    } else if (key == 'tags') {
+                        filterMap['tags'] = val.split(',')
+                    } else if (key == 'limit') {
+                        filterMap['limit'] = parseInt(val)
+                    } else if (key == 'tsrange') {
+                        filterMap['tsrange'] = val.split(',')
+                    }
+                }
+            }
+
+            for (var k=0; k<defaultKeys.length; k++) {
+                var key = defaultKeys[k]
+
+                if (filterKeys.includes(key) == false) {
+                    if (key == 'authors') {
+                        filterMap['authors'] = []
+                        filterMap['authors'].push("all")
+                    } else if (key == 'tags') {
+                        filterMap['tags'] = []
+                        filterMap['tags'].push("all")
+                    } else if (key == 'limit') {
+                        filterMap['limit'] = 50
+                    } else if (key == 'tsrange') {
+                        filterMap['tsrange'] = []
+                        filterMap['tsrange'].push(0)
+                        filterMap['tsrange'].push(Number.MAX_SAFE_INTEGER)
+                    }
+                }
+            }
+
+            authors = filterMap['authors']
+
+            authors_in = []
+            authors_ex = []
+            for(var i=0; i<authors.length; i++) {
+                if(authors[i].includes("^")) {
+                    s = authors[i].substring(1, authors[i].length)
+                    authors_ex.push(s)
+                }
+                else {
+                    authors_in.push(authors[i])
+                }
+            }
+
+            tags = filterMap['tags']
+
+            tags_in = []
+            tags_ex = []
+            for(var i=0; i<tags.length; i++) {
+                if(tags[i].includes("^")) {
+                    s = tags[i].substring(1, tags[i].length)
+                    tags_ex.push(s)
+                } else {
+                    tags_in.push(tags[i])
+                }
+            }
+
+            limit = filterMap['limit']
+
+            if(limit == -1) {
+                limit = Number.MAX_SAFE_INTEGER
+            }
+
+            tsrange = filterMap['tsrange']
+            if (tsrange.length == 2) {
+                tsfrom = parseInt(tsrange[0]) * 1000
+                tsto = parseInt(tsrange[1]) * 1000
+            } else {
+                return
+            }
+
+            if (authors.includes("all") && !tags.includes("all")) {
+                db.collection('contents').find({
+                    $and: [
+                        { pa: null },
+                        { author: { $nin : authors_ex } },
+                        {
+                            $or: [
+                                {
+                                    $and: [
+                                        { 'json.tag': { $in: tags_in } },
+                                        { 'json.tag': { $nin: tags_ex } },
+                                    ],
+                                },
+                                {
+                                    $and: [
+                                        { votes: { $elemMatch: { tag: { $in: tags_in } } } },
+                                        { votes: { $elemMatch: { tag: { $nin: tags_ex } } } }
+                                    ]
+                                }
+                            ]
+                        },
+                        { ts: { $gte: tsfrom } },
+                        { ts: { $lte: tsto } }
+                    ]
+                }, { sort: {ts:-1}, limit: limit}).toArray(function (err, contents) {
+                    res.send(contents)
+                })
+            } else if (!authors.includes("all") && !tags.includes("all")) {
+                db.collection('contents').find({
+                    $and: [
+                        { pa: null },
+                        { author: { $in : authors_in } },
+                        { author: { $nin : authors_ex } },
+                        {
+                            $or: [
+                                {
+                                    $and: [
+                                        { 'json.tag': { $in: tags_in } },
+                                        { 'json.tag': { $nin: tags_ex } },
+                                    ],
+                                },
+                                {
+                                    $and: [
+                                        { votes: { $elemMatch: { tag: { $in: tags_in } } } },
+                                        { votes: { $elemMatch: { tag: { $nin: tags_ex } } } }
+                                    ]
+                                }
+                            ]
+                        },
+                        { ts: { $gte: tsfrom } },
+                        { ts: { $lte: tsto } }
+                    ]
+                }, { sort: {ts:-1}, limit: limit }).toArray(function (err, contents) {
+                    res.send(contents)
+                })
+            } else if (authors.includes("all") && tags.includes("all")) {
+                db.collection('contents').find({
+                    $and: [
+                        { pa: null },
+                        { author: { $nin : authors_ex } },
+                        { 'json.tag': { $nin: tags_ex } },
+                        { votes: { $elemMatch: { tag: { $nin: tags_ex } } } },
+                        { ts: { $gte: tsfrom } },
+                        { ts: { $lte: tsto } }
+                    ]
+                }, { sort: {ts:-1}, limit: limit }).toArray(function (err, contents) {
+                    res.send(contents)
+                })
+            } else if (!authors.includes("all")  && tags.includes("all")) {
+                db.collection('contents').find({
+                    $and: [
+                        { pa: null },
+                        { author: { $in : authors_in } },
+                        { author: { $nin : authors_ex } },
+                        { 'json.tag': { $nin: tags_ex } },
+                        { votes: { $elemMatch: { tag: { $nin: tags_ex } } } },
+                        { ts: { $gte: tsfrom } },
+                        { ts: { $lte: tsto } }
+                    ]
+                }, { sort: {ts:-1}, limit: limit }).toArray(function (err, contents) {
+                    res.send(contents)
+                })
+            }
+        })
     }
 }

--- a/src/http/trending/index.js
+++ b/src/http/trending/index.js
@@ -20,5 +20,140 @@ module.exports = {
             }
             res.send(filteredContents)
         })
+        // get trending with tags and limit filter
+        app.get('/trending/:filter', (req, res) => {
+            var filterParam = req.params.filter
+            var filter = filterParam.split(':')
+            var filterBy = filter[1]
+            var filterAttrs = filterBy.split('&')
+
+            var filterMap = {}
+            var defaultKeys = ['tags', 'limit']
+            var filterKeys = []
+
+            for (var k=0; k<filterAttrs.length; k++) {
+                var kv = filterAttrs[k].split('=')
+
+                if (kv.length == 2) {
+                    var key = kv[0]
+                    filterKeys.push(key)
+                    var val = kv[1]
+
+                    if (key == 'tags') {
+                        filterMap['tags'] = val.split(',')
+                    } else if (key == 'limit') {
+                        filterMap['limit'] = parseInt(val)
+                    }
+                }
+            }
+
+            for (var k=0; k<defaultKeys.length; k++) {
+                var key = defaultKeys[k]
+
+                if (filterKeys.includes(key) == false) {
+                    if (key == 'tags') {
+                        filterMap['tags'] = []
+                        filterMap['tags'].push("all")
+                    } else if (key == 'limit') {
+                        filterMap['limit'] = Number.MAX_SAFE_INTEGER
+                    }
+                }
+            }
+
+            tags = filterMap['tags']
+
+            tags_in = []
+            tags_ex = []
+            for(var i=0; i<tags.length; i++) {
+                if(tags[i].includes("^")) {
+                    s = tags[i].substring(1, tags[i].length)
+                    tags_ex.push(s)
+                } else {
+                    tags_in.push(tags[i])
+                }
+            }
+
+            limit = filterMap['limit']
+
+            if(limit == -1) {
+                limit = Number.MAX_SAFE_INTEGER
+            }
+
+            var minTs = new Date().getTime() - rankings.types['trending'].halfLife*rankings.expireFactor
+
+            if (tags.includes('all')) {
+                db.collection('contents').find(
+                    {
+                        $and: [
+                            { pa: null },
+                            { 'json.tag': { $nin: tags_ex } },
+                            { votes: { $elemMatch: { tag: { $nin: tags_ex } } } },
+                            { ts: {'$gt': minTs} }
+                        ]
+                    },
+                    {sort: {ts: -1}}).toArray(function(err, contents) {
+                        for (let i = 0; i < contents.length; i++) {
+                            contents[i].score = 0
+                            contents[i].ups = 0
+                            contents[i].downs = 0
+                            if (!contents[i].dist) contents[i].dist = 0
+                            for (let y = 0; y < contents[i].votes.length; y++) {
+                                if (contents[i].votes[y].vt > 0)
+                                    contents[i].ups += Math.abs(contents[i].votes[y].vt)
+                                if (contents[i].votes[y].vt < 0)
+                                    contents[i].downs += Math.abs(contents[i].votes[y].vt)
+                            }
+                            contents[i].score = rankings.types['trending'].score(contents[i].ups, contents[i].downs, new Date(contents[i].ts))
+                        }
+                        contents = contents.sort(function(a,b) {
+                            return b.score - a.score
+                        })
+                        res.send(contents.slice(0, limit))
+                })
+            } else {
+                db.collection('contents').find(
+                    {
+                        $and: [
+                            { pa: null },
+                            {
+                                $or: [
+                                    {
+                                        $and: [
+                                            { 'json.tag': { $in: tags_in } },
+                                            { 'json.tag': { $nin: tags_ex } },
+                                        ],
+                                    },
+                                    {
+                                        $and: [
+                                            { votes: { $elemMatch: { tag: { $in: tags_in } } } },
+                                            { votes: { $elemMatch: { tag: { $nin: tags_ex } } } }
+                                        ]
+                                    }
+                                ]
+                            },
+                            { ts: {'$gt': minTs} }                        ]
+                    },
+                    {sort: {ts: -1}}).toArray(function(err, contents) {
+                        for (let i = 0; i < contents.length; i++) {
+                            contents[i].score = 0
+                            contents[i].ups = 0
+                            contents[i].downs = 0
+                            if (!contents[i].dist) contents[i].dist = 0
+                            for (let y = 0; y < contents[i].votes.length; y++) {
+                                if (contents[i].votes[y].vt > 0)
+                                    contents[i].ups += Math.abs(contents[i].votes[y].vt)
+                                if (contents[i].votes[y].vt < 0)
+                                    contents[i].downs += Math.abs(contents[i].votes[y].vt)
+                            }
+                            contents[i].score = rankings.types['hot'].score(contents[i].ups, contents[i].downs, new Date(contents[i].ts))
+                        }
+                        contents = contents.sort(function(a,b) {
+                            return b.score - a.score
+                        })
+                        //rankings.contents['hot'] = contents
+                        res.send(contents.slice(0, limit))
+                })
+            }
+        })
     }
 }

--- a/src/rankings.js
+++ b/src/rankings.js
@@ -6,6 +6,7 @@ const expireFactor = 5000 // disappears after 5 half times
 var isEnabled = process.env.RANKINGS || false
 
 var rankings = {
+    expireFactor: expireFactor,
     types: {
         hot: {
             halfLife: hotHalfTime,


### PR DESCRIPTION
Sorting options by timestamp (asc/desc) for /blog endpoint

This potentially works towards #66 

Sorting by oldest to newest (ts:-1) is done by sortBy=desc
Sorting by newest to oldest (ts:1) is done by sortBy=asc

query example: 
$API_URL/blog/d00k13/filter:sortBy=desc&limit=100000
$API_URL/blog/d00k13/filter:sortBy=asc&limit=100